### PR TITLE
Use new API proxy for PubChem completion suggestions

### DIFF
--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -501,7 +501,7 @@
               typeaheadSearch: function(val) {
                 return PubchemTypeahead.get(val)
                   .then(function(response) {
-                    return _.map(response.autocp_array, function(drugname) {
+                    return _.map(response, function(drugname) {
                       return { name: drugname };
                     });
                   });

--- a/src/components/services/PubchemTypeaheadService.js
+++ b/src/components/services/PubchemTypeaheadService.js
@@ -4,22 +4,15 @@
     .factory('PubchemTypeaheadResource', PubchemTypeaheadResource)
     .factory('PubchemTypeahead', PubchemTypeaheadService);
 
-  /*
-   * This resource uses the Pubchem autocomplete service, as documented here:
-   * https://pubchem.ncbi.nlm.nih.gov/widget/docs/widget_autocomplete_help.html#pc_compoundnames
-   */
 
   // @ngInject
   function PubchemTypeaheadResource($resource) {
-    return $resource('https://pubchem.ncbi.nlm.nih.gov/pcautocp/pcautocp.cgi',
-      {
-        dict: 'pc_compoundnames',
-        n: '20'
-      },
+    return $resource('/api/drugs/suggestions',
+      {},
       {
         get: {
           method: 'GET',
-          isArray: false,
+          isArray: true,
           cache: true
         }
       }
@@ -40,7 +33,7 @@
     function get(query) {
       return PubchemTypeaheadResource.get({q: query}).$promise
         .then(function(response) {
-          angular.copy(response.autocp_array, collection);
+          angular.copy(response, collection);
           return response.$promise;
         });
     }


### PR DESCRIPTION
This uses the new local API endpoint which searches both the PubChem API and our database when providing suggestions. 

I believe it fixes #345, but I want @jmcmichael to take a look at it first. It works, but I'm not sure I did it exactly right.