### PR TITLE
Added parameter to typeahead call to fit change in typeahead service

### DIFF
--- a/src/components/directives/quickSearch.js
+++ b/src/components/directives/quickSearch.js
@@ -21,7 +21,7 @@
     var topResult = {};
 
     $scope.getVariants = function (val) {
-      return TypeAheadResults.query({ query: val }).$promise
+      return TypeAheadResults.query({ query: val, limit: 12}).$promise
         .then(function (response) {
           var labelLimit = 75;
           return _.map(response.result, function (event, index) {


### PR DESCRIPTION
Typeahead service api changed in commit 2143b341753dee137799888d54a12308d335e812 broke the call made by quicksearch.