### PR TITLE
gulp build now automatically disables debug info

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -55,7 +55,6 @@ gulp.task('html', ['styles', 'scripts', 'partials', 'cdnize'], function () {
   var htmlFilter = $.filter('*.html', {restore: true});
   var jsFilter = $.filter('**/*.js', {restore: true});
   var cssFilter = $.filter('**/*.css', {restore: true});
-  $.gulpif = require('gulp-if');
 
   return gulp.src('.tmp/*.html')
     .pipe($.inject(
@@ -97,7 +96,7 @@ gulp.task('html', ['styles', 'scripts', 'partials', 'cdnize'], function () {
     }))
 
     // init asset revisioning with gulp-rev on each block
-    .pipe($.gulpif("!*.html",$.rev()))
+    .pipe($.if("!*.html",$.rev()))
 
     // pluck javascript block, store everything else
     .pipe(jsFilter)
@@ -181,4 +180,12 @@ gulp.task('clean', function (done) {
   $.del(['.tmp', 'dist'], done);
 });
 
-gulp.task('build', ['html', 'images', 'fonts', 'misc']);
+gulp.task('e2e:build', ['html', 'images', 'fonts', 'misc']);
+
+gulp.task('build', ['e2e:build'], function(){
+
+  return gulp.src('dist/scripts/app*.js')
+    .pipe($.replace(/window\.apiCheck\.disabled=![01]/g, 'window.apiCheck.disabled=!0'))
+    .pipe($.replace(/\.debugInfoEnabled\(![01]\)/g, '.debugInfoEnabled(!1);'))
+    .pipe(gulp.dest('dist/scripts'))
+});

--- a/gulp/e2e-tests.js
+++ b/gulp/e2e-tests.js
@@ -15,7 +15,7 @@ gulp.task('test:e2e', ['serve'], function() {
     .once('end', function() { process.exit(); });
 });
 
-gulp.task('test:e2e:dist', ['serve:dist'], function() {
+gulp.task('test:e2e:dist', ['serve:e2e-dist-static'], function() {
   gulp.src(['test/e2e/**/*.spec.js'])
     .pipe(angularProtractor({
       'configFile': 'test/protractor.conf.js',

--- a/gulp/server.js
+++ b/gulp/server.js
@@ -46,10 +46,14 @@ gulp.task('serve:dist', ['build'], function () {
   connectInit(['dist', path.resolve('./')], false);
 });
 
-gulp.task('serve:e2e', ['build'], function () {
+gulp.task('serve:e2e', ['watch'], function () {
   connectInit(['src', '.tmp', path.resolve('./')], false);
 });
 
-gulp.task('serve:e2e-dist', ['build', 'watch'], function () {
+gulp.task('serve:e2e-dist', ['e2e:build', 'watch'], function () {
   connectInit(['dist', path.resolve('./')], true);
+});
+
+gulp.task('serve:e2e-dist-static', ['e2e:build'], function () {
+  connectInit(['dist', path.resolve('./')], false);
 });


### PR DESCRIPTION
Use `gulp e2e:build` to build with debug info (e2e:build produces output identical to the old `gulp build`)

Close #453 