### PR TITLE
Rework gulp tasks

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -79,7 +79,7 @@ gulp.task('html', ['styles', 'scripts', 'partials', 'cdnize'], function () {
         var scripts = content.split(/\r?\n/gm);
         var output = "";
         //prepare the build tag for the next run of useref
-        var parse = "<!-- build:"+mode+"("+altPath+") "+target+" -->\n";
+        var parse = "<!-- build:"+mode+(altPath?"("+altPath+") ":' ')+target+" -->\n";
         scripts.forEach(function(line){
           if(line.search(/(cloudflare\.com|googleapis\.com|jsdelivr\.net)/g)!=-1)
           {

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -69,10 +69,7 @@ gulp.task('html', ['styles', 'scripts', 'partials', 'cdnize'], function () {
       }))
 
 
-
     // parse index.html for links to asset (scripts, html, css), group, concatenate, add to stream
-    .pipe($.useref()) //Run useref on any vendor files which couldn't be cdnized
-
     //This call to useref will parse all app assets and concatenate
     //It also filters out any remote assets which have been cdnized,
     //leaving only those which couldn't behind to be parsed into vendor files
@@ -84,7 +81,7 @@ gulp.task('html', ['styles', 'scripts', 'partials', 'cdnize'], function () {
         //prepare the build tag for the next run of useref
         var parse = "<!-- build:"+mode+"("+altPath+") "+target+" -->\n";
         scripts.forEach(function(line){
-          if(line.search(/(cloudflare.com|googleapis.com|jsdelivr.net)/g)!=-1)
+          if(line.search(/(cloudflare\.com|googleapis\.com|jsdelivr\.net)/g)!=-1)
           {
             output+=line+"\n";
           }
@@ -96,6 +93,9 @@ gulp.task('html', ['styles', 'scripts', 'partials', 'cdnize'], function () {
         return output+"\n"+parse;
       }
     }))
+
+    .pipe($.useref()) //Second call to useref picks up the vendor files which weren't cdnized
+    //and concatenates into vendor.{js,css}
 
     // init asset revisioning with gulp-rev on each block
     .pipe($.if("!*.html",$.rev()))

--- a/gulp/cdnize.js
+++ b/gulp/cdnize.js
@@ -4,7 +4,7 @@ var gulp = require('gulp');
 var cdnizer = require('gulp-cdnizer');
 
 gulp.task('cdnize', ['wiredep'], function () {
-  return gulp.src('src/*.html')
+  return gulp.src('.tmp/*.html')
   .pipe(cdnizer({
     //configure cdnizer's version and naming settings
     allowRev: false, //stricter version matching

--- a/gulp/server.js
+++ b/gulp/server.js
@@ -40,11 +40,12 @@ function connectInit(baseDir, livereload) {
   });
 }
 
+
 gulp.task('serve', ['images', 'fonts', 'watch'], function () {
   connectInit([
-    './.tmp',
-    './src',
-    './docs',
+    '.tmp',
+    'src',
+    'docs',
     path.resolve('./') // include root (kludge necessary to make bower_components available where index.html expects them)
   ], true);
 });

--- a/gulp/server.js
+++ b/gulp/server.js
@@ -42,8 +42,8 @@ function connectInit(baseDir, livereload) {
 
 gulp.task('serve', ['images', 'fonts', 'watch'], function () {
   connectInit([
-    './src',
     './.tmp',
+    './src',
     './docs',
     path.resolve('./') // include root (kludge necessary to make bower_components available where index.html expects them)
   ], true);
@@ -54,7 +54,7 @@ gulp.task('serve:dist', ['build'], function () {
 });
 
 gulp.task('serve:e2e', ['watch'], function () {
-  connectInit(['src', '.tmp', path.resolve('./')], false);
+  connectInit(['.tmp', 'src', path.resolve('./')], false);
 });
 
 gulp.task('serve:e2e-dist', ['e2e:build', 'watch'], function () {

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -3,7 +3,7 @@
 var gulp = require('gulp');
 var connect = require('gulp-connect');
 
-gulp.task('watch', ['styles', 'partials'] ,function () {
+gulp.task('watch', ['styles', 'liveinject'] ,function () {
   gulp.watch('src/{app,components}/**/*.less', ['styles'])
     .on('change', function(file) {gulp.src(file.path).pipe(connect.reload());});
 
@@ -13,10 +13,24 @@ gulp.task('watch', ['styles', 'partials'] ,function () {
   gulp.watch('src/assets/images/**/*', ['images'])
     .on('change', function(file) {gulp.src(file.path).pipe(connect.reload());});
 
-  gulp.watch(['src/index.html', 'bower.json'], ['wiredep'])
+  gulp.watch(['src/index.html', 'bower.json'], ['liveinject'])
     .on('change', function(file) {gulp.src(file.path).pipe(connect.reload());});
 
-  gulp.watch('src/{app,components}/**/*.html', ['partials'])
+  gulp.watch('src/{app,components}/**/*.html', ['liveinject'])
     .on('change', function(file) {gulp.src(file.path).pipe(connect.reload());});
 
 });
+
+gulp.task('liveinject', ['wiredep', 'partials'], function(){
+  var inject = require('gulp-inject');
+  return gulp.src('.tmp/*.html')
+    .pipe(inject(
+      // stream JS files in app/component directories
+      gulp.src('.tmp/{app,components}/**/*.js'),
+      {
+        starttag: '<!-- inject:partials -->',
+        addRootSlash: false,
+        addPrefix: '../'
+      }))
+    .pipe(gulp.dest('.tmp'))
+})

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -3,7 +3,7 @@
 var gulp = require('gulp');
 var connect = require('gulp-connect');
 
-gulp.task('watch', ['styles'] ,function () {
+gulp.task('watch', ['styles', 'partials'] ,function () {
   gulp.watch('src/{app,components}/**/*.less', ['styles'])
     .on('change', function(file) {gulp.src(file.path).pipe(connect.reload());});
 
@@ -14,6 +14,9 @@ gulp.task('watch', ['styles'] ,function () {
     .on('change', function(file) {gulp.src(file.path).pipe(connect.reload());});
 
   gulp.watch(['src/index.html', 'bower.json'], ['wiredep'])
+    .on('change', function(file) {gulp.src(file.path).pipe(connect.reload());});
+
+  gulp.watch('src/{app,components}/**/*.html', ['partials'])
     .on('change', function(file) {gulp.src(file.path).pipe(connect.reload());});
 
 });

--- a/gulp/wiredep.js
+++ b/gulp/wiredep.js
@@ -19,5 +19,5 @@ gulp.task('wiredep', function () {
         /SHA-1.js/
       ]
     }))
-    .pipe(gulp.dest('src'));
+    .pipe(gulp.dest('.tmp'));
 });

--- a/gulp/wiredep.js
+++ b/gulp/wiredep.js
@@ -6,7 +6,7 @@ var gulp = require('gulp');
 gulp.task('wiredep', function () {
   var wiredep = require('wiredep').stream;
 
-  return gulp.src('src/index.html')
+  return gulp.src('src/{index,404}.html')
     .pipe(wiredep({
       directory: 'bower_components',
       exclude: [

--- a/src/index.html
+++ b/src/index.html
@@ -31,12 +31,7 @@
     <!-- build:filter_cdn({.tmp,src}) styles/vendor.css css -->
 
     <!-- bower:css -->
-    <link rel="stylesheet" href="../bower_components/angular-ui-grid/ui-grid.css" />
-    <link rel="stylesheet" href="../bower_components/angular-dialog-service/dist/dialogs.min.css" />
-    <link rel="stylesheet" href="../bower_components/font-awesome/css/font-awesome.css" />
-    <link rel="stylesheet" href="../bower_components/ngDialog/css/ngDialog.css" />
-    <link rel="stylesheet" href="../bower_components/ngDialog/css/ngDialog-theme-default.css" />
-    <link rel="stylesheet" href="../bower_components/angular-loading-bar/build/loading-bar.css" />
+
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -367,33 +362,7 @@
 
     <!-- build:filter_cdn scripts/vendor.js js -->
     <!-- bower:js -->
-    <script src="../bower_components/angular/angular.js"></script>
-    <script src="../bower_components/angular-ui-router/release/angular-ui-router.js"></script>
-    <script src="../bower_components/angular-sanitize/angular-sanitize.js"></script>
-    <script src="../bower_components/api-check/dist/api-check.js"></script>
-    <script src="../bower_components/angular-formly/dist/formly.js"></script>
-    <script src="../bower_components/ui-router-extras/release/ct-ui-router-extras.js"></script>
-    <script src="../bower_components/angular-ui-grid/ui-grid.js"></script>
-    <script src="../bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
-    <script src="../bower_components/angular-translate/angular-translate.js"></script>
-    <script src="../bower_components/angular-dialog-service/dist/dialogs.min.js"></script>
-    <script src="../bower_components/angular-dialog-service/dist/dialogs-default-translations.min.js"></script>
-    <script src="../bower_components/lodash/lodash.js"></script>
-    <script src="../bower_components/angular-resource/angular-resource.js"></script>
-    <script src="../bower_components/angular-timeago/src/timeAgo.js"></script>
-    <script src="../bower_components/SHA-1/sha1.js"></script>
-    <script src="../bower_components/angulartics/src/angulartics.js"></script>
-    <script src="../bower_components/angulartics-google-analytics/lib/angulartics-ga.js"></script>
-    <script src="../bower_components/ngDialog/js/ngDialog.js"></script>
-    <script src="../bower_components/angular-loading-bar/build/loading-bar.js"></script>
-    <script src="../bower_components/angular-formly-templates-bootstrap/dist/angular-formly-templates-bootstrap.js"></script>
-    <script src="../bower_components/angular-messages/angular-messages.js"></script>
-    <script src="../bower_components/angular-touch/angular-touch.js"></script>
-    <script src="../bower_components/angular-scroll/angular-scroll.js"></script>
-    <script src="../bower_components/angular-elastic/elastic.js"></script>
-    <script src="../bower_components/ment.io/dist/mentio.js"></script>
-    <script src="../bower_components/d3/d3.js"></script>
-    <script src="../bower_components/dimple/dist/dimple.latest.js"></script>
+
     <!-- endbower -->
     <!-- endbuild -->
 


### PR DESCRIPTION
All the gulp tasks now leave src/ files completely untouched.

`wiredep` now moves index.html and 404.html into .tmp when adding bower dependencies
`cdnize` now picks up index.html and 404.html from .tmp, but drops them straight back into .tmp after cdnizing dependencies
`serve` and `serve:e2e` still work as before, but search through .tmp first when locating files (so they'll find the wiredep-ed index.html and 404.html before the raw ones in src)

Also removed all tags to bower dependencies from src/index.html

Added `liveinject` task to process changed partials (by running `partials`) then inject them into .tmp/index.html so partials are added to the template cache
`watch` task now calls `liveinject` and reloads when changes are made to any templates or index.html
