### PR TITLE
fix typo in variable name for dbsnpfp display field

### DIFF
--- a/src/app/views/events/variants/summary/myVariantInfoDialog.tpl.html
+++ b/src/app/views/events/variants/summary/myVariantInfoDialog.tpl.html
@@ -50,7 +50,7 @@
           </tr>
           <tr>
             <td class="key">dbsnpfp.interpro_domain</td>
-            <td class="value">{{variantInfo.clinvar.omim | ifEmpty: '--'}}</td>
+            <td class="value">{{variantInfo.dbsnpfp.interpro_domain | ifEmpty: '--'}}</td>
           </tr>
           <tr>
             <td class="key">emv.egl_protein</td>


### PR DESCRIPTION
Just a minor patch.  Assume this is correct, but submitting as PR so that @jmcmichael has a chance to confirm.