### PR TITLE
Add support for display and modification of ClinVar ID

### DIFF
--- a/src/app/views/events/variants/edit/variantEditBasic.js
+++ b/src/app/views/events/variants/edit/variantEditBasic.js
@@ -135,6 +135,25 @@
         }
       },
       {
+        key: 'clinvar_entries',
+        type: 'multiInput',
+        templateOptions: {
+          label: 'ClinVar IDs',
+          helpText: 'Please specify any corresponding ClinVar identifiers for this variant.',
+          entityName: 'ClinVar ID',
+          required: false,
+          inputOptions: {
+            type: 'basicInput',
+            wrapper: '',
+            templateOptions: {
+              label: '',
+              minLength: 1,
+              required: true
+            }
+          }
+        }
+      },
+      {
         key: 'sources',
         type: 'multiInput',
         templateOptions: {

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -56,7 +56,22 @@
               </span>
             </p>
           </div>
-
+          <div class="clinvar-ids">
+            <p>
+              <strong>ClinVar ID<span ng-if="variant.clinvar_entries.length > 1">s</span>:</strong><br/>
+              <span ng-switch="variant.clinvar_entries.length > 0">
+                <span ng-switch-when="true">
+                  <span ng-repeat="clinvar_id in variant.clinvar_entries" class="small">
+                    {{$first ? '' : $last ? ', and ' : ', '}}
+                    <a ng-href="https://www.ncbi.nlm.nih.gov/clinvar/variation/{{ clinvar_id }}/" target="_blank">{{ clinvar_id }}</a>
+                  </span>
+                </span>
+                <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
+                  None specified.
+                </span>
+              </span>
+            </p>
+          </div>
         </div>
         <div class="col-xs-12 col-md-6">
           <div ng-if="variant.sources.length > 0">


### PR DESCRIPTION
Variants now have a (moderated) clinvar entries field which links out to clinvar as appropriate. This is the frontend support for genome/civic-server#265.