### PR TITLE
Secondary Gene Support for Variants

### DIFF
--- a/src/app/views/events/variants/edit/variantEditBasic.js
+++ b/src/app/views/events/variants/edit/variantEditBasic.js
@@ -423,6 +423,16 @@
         }
       },
       {
+        model: vm.variantEdit.coordinates.secondary_gene,
+        key: 'name',
+        type: 'horizontalInputHelp',
+        templateOptions: {
+          label: 'Secondary Gene',
+          value: vm.variantEdit.coordinates.secondary_gene.id,
+          helpText: 'For fusion variants, a secondary gene may be specified.'
+        }
+      },
+      {
         template: '<hr/>'
       },
       {

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -178,6 +178,26 @@
             </tbody>
           </table>
         </div>
+        <div ng-if="variant.coordinates.secondary_gene">
+          <div class="section-title">
+            SECONDARY GENE
+          </div>
+          <table class="table table-condensed borderless">
+            <tbody class="common">
+              <tr>
+                <td class="key">
+                  Gene Name
+                </td>
+              <tr>
+                <td class="value">
+                  <a ng-href="#/events/genes/{{variant.coordinates.secondary_gene.id}}/summary">
+                      {{variant.coordinates.secondary_gene.name | ifEmpty: '--'}}
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         <div ng-if="isAuthenticated() && !isEdit">
           <a class="btn btn-default btn-xs btn-block"
              ng-click="editClick()">Edit Coordinates</a>


### PR DESCRIPTION
This is some extremely rudimentary support for secondary genes in the client. Basically it does two things:

* Displays the gene name and links to the gene page for the secondary gene, if its present
* Stubs in a form field in the variant edit form for secondary gene.

I couldn't get the Gene typeahead working on the field like I wanted; I tried to adapt the one found at `app/views/add/evidence/addEvidenceBasic.js` because I'd like this field to work similarly to the gene field there, but was unable to get it working. We'll want to get that working before merging this, so I will give it another go!