### PR TITLE
Ability to search evidence records for empty rating

### DIFF
--- a/src/app/pages/home.tpl.html
+++ b/src/app/pages/home.tpl.html
@@ -109,7 +109,7 @@
           icon-url=""
           cols="col-xs-4">
         </stats-block>
-      </div>-->
+      </div>
     </div>
     <div class="col-xs-12 col-sm-6 stats-block">
       <div class="row">

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -108,10 +108,15 @@
                     { value: 'is_less_than', name: 'is less than' },
                     { value: 'is_less_than_or_equal_to', name: 'is less than or equal to' },
                     { value: 'is_equal_to', name: 'is equal to' },
-                    { value: 'is_in_the_range', name: 'is in the range'}
+                    { value: 'is_in_the_range', name: 'is in the range'},
+                    { value: 'is_undefined', name: 'is undefined'}
                   ],
                   onChange: function(value, options, scope) {
-                    _.pullAt(scope.model.parameters, 1,2);
+                    console.log(scope.model.parameters);
+                    _.pullAt(scope.model.parameters, 1);
+                    if (scope.model.name == "is_undefined"){
+                      _.pullAt(scope.model.parameters, 0);
+                    }
                   }
                 }
               },
@@ -119,6 +124,7 @@
                 key: 'parameters[0]',
                 type: 'rating',
                 className: 'inline-field',
+                hideExpression: 'model.name == "is_undefined"',
                 templateOptions: {
                   label: '',
                   required: true
@@ -2528,7 +2534,7 @@
           tooltip: 'Variants with a variant starting between 16 and 60K in its primary chromosome',
           search: {'operator':'AND','queries':[{'field':'start','condition':{'name':'is_in_the_range','parameters':['16000000','60000000']}}]}
         },
-        { 
+        {
           name: 'Variant type contains frameshift',
           tooltip: 'Variants with a variant type that contains the world frameshift',
           search: {'operator':'AND','queries':[{'field':'variant_types','condition':{'name':'contains','parameters':['frameshift']}}]}

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -112,7 +112,6 @@
                     { value: 'is_undefined', name: 'is undefined'}
                   ],
                   onChange: function(value, options, scope) {
-                    console.log(scope.model.parameters);
                     _.pullAt(scope.model.parameters, 1);
                     if (scope.model.name == "is_undefined"){
                       _.pullAt(scope.model.parameters, 0);

--- a/src/components/filters.js
+++ b/src/components/filters.js
@@ -22,7 +22,7 @@
   }
 
   // @ngInject
-  function highlightSearch(){
+  function highlightSearch(_){
     return function (input, query) {
       return input.toString().replace(RegExp('('+ _.escapeRegExp(query)+ ')', 'gi'), '<strong>$1</strong>');
     }


### PR DESCRIPTION
Ok to merge now, genome/civic-server#280 has been merged

Adds an option to query the database for evidence records with undefined values.

closes #638 