### PR TITLE
Reload variant name

### DIFF
--- a/src/app/views/events/common/entityTabs.js
+++ b/src/app/views/events/common/entityTabs.js
@@ -77,10 +77,13 @@
 
     scope.$watch('entityViewModel.data.item.name', function(name) {
       vm.name = name;
+      console.log(entityViewModel.data); // new variant object "LAST"
+      console.log(name); // new value for name "LAST"
     });
 
     scope.$watchCollection('entityViewModel.data.item.lifecycle_actions', function(lifecycle_actions) {
       vm.actions = lifecycle_actions;
+      console.log("actions");
     });
 
     scope.viewBackground = 'view-' + entityViewOptions.styles.view.backgroundColor;

--- a/src/app/views/events/common/entityTabs.js
+++ b/src/app/views/events/common/entityTabs.js
@@ -77,13 +77,10 @@
 
     scope.$watch('entityViewModel.data.item.name', function(name) {
       vm.name = name;
-      console.log(entityViewModel.data); // new variant object "LAST"
-      console.log(name); // new value for name "LAST"
     });
 
     scope.$watchCollection('entityViewModel.data.item.lifecycle_actions', function(lifecycle_actions) {
       vm.actions = lifecycle_actions;
-      console.log("actions");
     });
 
     scope.viewBackground = 'view-' + entityViewOptions.styles.view.backgroundColor;

--- a/src/app/views/events/common/entityTalkTabs.js
+++ b/src/app/views/events/common/entityTalkTabs.js
@@ -41,7 +41,7 @@
   function entityTalkTabsLink(scope, element, attributes, entityTalkView) {
     var viewModel = scope.viewModel = entityTalkView.viewModel;
     var viewOptions = scope.viewOptions = entityTalkView.viewOptions;
-
+    //console.log(viewOptions.tabData);
     scope.type = viewModel.data.item.type;
     scope.name = viewModel.data.item.name;
     scope.showCorner = (scope.type === 'variant' || scope.type === 'variant group');
@@ -56,6 +56,27 @@
     if (!angular.isArray(scope.tabs)) {
       throw new Error('entityTalkTabs: \'data\' attribute must be an array of tab data with at least one tab defined.');
     }
+
+    scope.$on('revisionDecision', function(event, args){
+      entityTalkView.viewModel.get(entityTalkView.viewModel.data.item.id)
+      .then(function(fields) {
+        //variant.name + ' Revisions'
+        scope.tabs.forEach(function(elem, index, arr){
+          var end = elem.heading.split(" ")[1];
+          arr[index].heading = fields.name + " " + end;
+        });
+      });
+      //scope.tabs = entityTalkView.viewOptions.tabData;
+      //console.log(viewOptions);
+      // console.log(entityTalkView.viewOptions);
+      // console.log("I heard you");
+      // entityTalkView.viewOptions.query(entityTalkView.viewOptions.data.id)
+      // .then(function(fields) {
+      //   console.log(entityTalkView.viewOptions.tabData);
+      //   console.log("what it do");
+      //   console.log(fields);
+      // });
+    });
 
     var unbindStateChangeSuccess = scope.$on(
       '$stateChangeSuccess',

--- a/src/app/views/events/common/entityTalkTabs.js
+++ b/src/app/views/events/common/entityTalkTabs.js
@@ -60,22 +60,11 @@
     scope.$on('revisionDecision', function(event, args){
       entityTalkView.viewModel.get(entityTalkView.viewModel.data.item.id)
       .then(function(fields) {
-        //variant.name + ' Revisions'
         scope.tabs.forEach(function(elem, index, arr){
           var end = elem.heading.split(" ")[1];
           arr[index].heading = fields.name + " " + end;
         });
       });
-      //scope.tabs = entityTalkView.viewOptions.tabData;
-      //console.log(viewOptions);
-      // console.log(entityTalkView.viewOptions);
-      // console.log("I heard you");
-      // entityTalkView.viewOptions.query(entityTalkView.viewOptions.data.id)
-      // .then(function(fields) {
-      //   console.log(entityTalkView.viewOptions.tabData);
-      //   console.log("what it do");
-      //   console.log(fields);
-      // });
     });
 
     var unbindStateChangeSuccess = scope.$on(

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -26,18 +26,21 @@
 
     $scope.$state = $state;
 
+    /*
     $scope.$on('revisionDecision', function(){
-      Genes.get(Genes.data.item.id)
-      Genes.queryVariants(Genes.data.item.id)
+      //Genes.get(Genes.data.item.id);
+      Genes.update(Genes.data.item.id)
       .then(function(fields){
-        $scope.variants.forEach(function(elem, index, arr){
-          Variants.get(arr[index].id)
-          .then(function(fields){
-            arr[index].name = fields.name; // need to deal with evidence_items and make sure no hiccups with adding variant groups
-          });
-        });
+        console.log(fields); // giving me old value
+        //$scope.variants.forEach(function(elem, index, arr){
+          //Variants.get(arr[index].id)
+          //.then(function(fields){
+            //arr[index].name = fields.name; // need to deal with evidence_items and make sure no hiccups with adding variant groups
+          //});
+        //}); 
       });
     });
+    */
 
     $scope.hasValidEvidenceItems = function(variant) {
       var non_rejected_count = _.reduce(variant.evidence_items, function(acc, val, key) {

--- a/src/app/views/events/genes/summary/variantMenu.js
+++ b/src/app/views/events/genes/summary/variantMenu.js
@@ -14,7 +14,7 @@
     });
 
   //@ngInject
-  function VariantMenuController($scope, $state, $stateParams, Genes, Security, _) {
+  function VariantMenuController($scope, $state, $stateParams, Genes, Variants, Security, _) {
     $scope.gene = Genes.data.item;
     $scope.variants = Genes.data.variants;
     $scope.stateParams = $stateParams;
@@ -25,6 +25,19 @@
     };
 
     $scope.$state = $state;
+
+    $scope.$on('revisionDecision', function(){
+      Genes.get(Genes.data.item.id)
+      Genes.queryVariants(Genes.data.item.id)
+      .then(function(fields){
+        $scope.variants.forEach(function(elem, index, arr){
+          Variants.get(arr[index].id)
+          .then(function(fields){
+            arr[index].name = fields.name; // need to deal with evidence_items and make sure no hiccups with adding variant groups
+          });
+        });
+      });
+    });
 
     $scope.hasValidEvidenceItems = function(variant) {
       var non_rejected_count = _.reduce(variant.evidence_items, function(acc, val, key) {
@@ -44,13 +57,12 @@
         $scope.addVarGroupUrl = addVarGroupUrlBase + '?geneId=' + stateParams.geneId;
       }
     });
-
+    
     $scope.$watchCollection(
       function() { return Genes.data.variants; },
       function(variants){
         $scope.variants = variants;
       });
-
 
     $scope.$watchCollection(
       function() { return Genes.data.variantGroups; },

--- a/src/components/services/GenesService.js
+++ b/src/components/services/GenesService.js
@@ -9,7 +9,7 @@
     var cache = $cacheFactory.get('$http');
 
     var cacheInterceptor = function(response) {
-      // console.log(['GenesResource: removing', response.config.url, 'from $http cache.'].join(' '));
+      console.log(['GenesResource: removing', response.config.url, 'from $http cache.'].join(' '));
       cache.remove(response.config.url);
       return response.$promise;
     };
@@ -129,13 +129,13 @@
           method: 'GET',
           url: '/api/genes/:geneId/variants',
           isArray: false,
-          cache: cache
+          cache: false
         },
         queryVariantGroups: {
           method: 'GET',
           url: '/api/genes/:geneId/variant_groups',
           isArray: false,
-          cache: cache
+          cache: false
         },
 
         // Gene Comments Resources
@@ -278,8 +278,8 @@
           return response.$promise;
         });
     }
-    function update(reqObj) {
-      return GenesResource.update(reqObj).$promise
+    function update(reqObj) { // geneId to reqObj
+      return GenesResource.update(reqObj).$promise //obj to reqObj
         .then(function(response) {
           angular.copy(response, item);
           return response.$promise;
@@ -330,8 +330,11 @@
     function queryVariants(geneId) {
       return GenesResource.queryVariants({geneId: geneId, count: 999}).$promise
         .then(function(response) {
+          console.log(response); // old value
+          console.log(variants); // old value
           angular.copy(response.records, variants);
-          return response.$promise;
+          console.log(variants); // old value
+          return response.$promise; // old value
         });
     }
     function queryVariantGroups(geneId) {


### PR DESCRIPTION
implemented broadcast/on for entityTalkTabs, changed GenesService caching to false for queryVariants and queryVariantGroups... may want to revisit this later but I believe this is the only way for $watchcollection to notice that the variants and variantgroups are changing - in any case, probably could go back and implement an update request/removing variants from cache upon broadcasting 'revisionDecision'

Should fix issue #323