### PR TITLE
Add display of aliases to gene typeahead

### DIFF
--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -126,7 +126,7 @@
           required: true,
           editable: false,
           formatter: 'model[options.key].name',
-          typeahead: 'item as item.name for item in to.data.typeaheadSearch($viewValue)',
+          typeahead: 'item as item.name + " aliases: ("+ item.aliases.join(", ") + ")" for item in to.data.typeaheadSearch($viewValue)',
           onSelect: 'to.data.entrez_id = $model.entrez_id',
           helpText: help['Gene Entrez Name'],
           data: {


### PR DESCRIPTION
closes genome/civic-server#284


I added the aliases to the server side response on the typeahead and am now displaying them. But its ugly. I'm certain there's a better way to do this so please feel free to disregard this pr :-D 