### PR TITLE
Constrain input coordinates rather than freetext

### DIFF
--- a/src/app/views/events/variants/edit/variantEditBasic.js
+++ b/src/app/views/events/variants/edit/variantEditBasic.js
@@ -26,6 +26,7 @@
                                       VariantHistory,
                                       VariantsViewOptions,
                                       Publications,
+                                      ConfigService,
                                       formConfig,
                                       _,
                                       $rootScope) {
@@ -323,10 +324,12 @@
       {
         model: vm.variantEdit.coordinates,
         key: 'chromosome',
-        type: 'horizontalInputHelp',
+        type: 'horizontalSelectHelp',
         templateOptions: {
           label: 'Chromosome',
           value: vm.variantEdit.coordinates.chromosome,
+          ngOptions: 'option["value"] as option["name"] for option in to.options',
+          options: ConfigService.valid_chromosomes,
           helpText: 'Chromosome in which this variant occurs (e.g. 17).'
         }
       },
@@ -386,10 +389,12 @@
       {
         model: vm.variantEdit.coordinates,
         key: 'chromosome2',
-        type: 'horizontalInputHelp',
+        type: 'horizontalSelectHelp',
         templateOptions: {
-          label: 'Chromosome 2',
+          label: 'Chromosome2',
           value: vm.variantEdit.coordinates.chromosome2,
+          ngOptions: 'option["value"] as option["name"] for option in to.options',
+          options: ConfigService.valid_chromosomes,
           helpText: 'If this variant is a fusion (e.g. BCR-ABL1), specify the chromosome name, coordinates, and representative transcript for the 3-prime partner.'
         }
       },

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -6,7 +6,8 @@
   // @ngInject
   function SearchController($scope,
                             _,
-                            Diseases) {
+                            Diseases,
+                            ConfigService) {
     var vm = $scope.vm = {};
 
     vm.suggestedSearch = {};
@@ -1506,12 +1507,15 @@
               },
               {
                 key: 'parameters[0]',
-                type: 'input',
+                type: 'queryBuilderSelect',
                 className: 'inline-field',
-                hideExpression: 'model.name === "is_empty"',
+                data: {
+                  defaultValue: '1'
+                },
                 templateOptions: {
                   label: '',
-                  required: true
+                  required: true,
+                  options: ConfigService.valid_chromosomes
                 }
               }
             ],
@@ -1663,12 +1667,15 @@
               },
               {
                 key: 'parameters[0]',
-                type: 'input',
+                type: 'queryBuilderSelect',
                 className: 'inline-field',
-                hideExpression: 'model.name === "is_empty"',
+                data: {
+                  defaultValue: '1'
+                },
                 templateOptions: {
                   label: '',
-                  required: true
+                  required: true,
+                  options: ConfigService.valid_chromosomes
                 }
               }
             ],

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -253,6 +253,33 @@
           }
         ]
       },
+      valid_chromosomes: [
+        { value: '1', name: '1' },
+        { value: '2', name: '2' },
+        { value: '3', name: '3' },
+        { value: '4', name: '4' },
+        { value: '5', name: '5' },
+        { value: '6', name: '6' },
+        { value: '7', name: '7' },
+        { value: '8', name: '8' },
+        { value: '9', name: '9' },
+        { value: '10', name: '10' },
+        { value: '11', name: '11' },
+        { value: '12', name: '12' },
+        { value: '13', name: '13' },
+        { value: '14', name: '14' },
+        { value: '15', name: '15' },
+        { value: '16', name: '16' },
+        { value: '17', name: '17' },
+        { value: '18', name: '18' },
+        { value: '19', name: '19' },
+        { value: '20', name: '20' },
+        { value: '21', name: '21' },
+        { value: '22', name: '22' },
+        { value: 'X', name: 'X' },
+        { value: 'Y', name: 'Y' },
+        { value: 'MT', name: 'MT' }
+      ],
       evidenceAttributeDescriptions: {
         variant_origin: {
           'Somatic Mutation': 'Variant is a mutation, found only in tumor cells, having arisen in a specific tissue (non-germ cell), and is not expected to be inherited or passed to offspring.',


### PR DESCRIPTION
The server side changes are done, and this is the client side part of genome/civic-server#83.

I've tried it out on both the variant edit page and the variant advanced search page and its working as intended. The one addition I think this needs is to introduce a blank or "unset" value in the `select` tags in the variant edit form which I wasn't sure how to do. One appears if the value is currently blank, but not once a value has been selected.
