### PR TITLE
reject and submit revisions now requery variant after cache removal

### DIFF
--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -260,7 +260,9 @@
           vm.pubmedName = '';
 
           function searchForDups(values) {
+            console.log("searchForDups");
             if(_.every(values, function(val) { return _.isString(val) && val.length > 0; })) {
+              vm.duplicates = [];
               Search.post({
                   'operator': 'AND',
                   'queries': [

--- a/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.js
+++ b/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.js
@@ -46,7 +46,7 @@
     $scope.acceptRevision = function() {
       vm.formErrors = {};
       vm.formMessages = {};
-      EvidenceRevisions.acceptRevision($stateParams.evidenceId, $stateParams.revisionId,$stateParams.variantId)
+      EvidenceRevisions.acceptRevision($stateParams.evidenceId, $stateParams.revisionId, $stateParams.variantId)
         .then(function() {
           vm.formMessages.acceptSuccess = true;
           $rootScope.$broadcast('revisionDecision');
@@ -63,7 +63,7 @@
     $scope.rejectRevision = function() {
       vm.formErrors = {};
       vm.formMessages = {};
-      EvidenceRevisions.rejectRevision($stateParams.evidenceId, $stateParams.revisionId)
+      EvidenceRevisions.rejectRevision($stateParams.evidenceId, $stateParams.revisionId, $stateParams.variantId)
         .then(function() {
           vm.formMessages.rejectSuccess = true;
           $rootScope.$broadcast('revisionDecision');

--- a/src/app/views/events/variants/summary/variantSummary.js
+++ b/src/app/views/events/variants/summary/variantSummary.js
@@ -28,6 +28,7 @@
     $scope.variant = parseVariant(Variants.data.item);
     $scope.evidence = Variants.data.evidence;
 
+    // watches any changes to the variant itself, but will also update evidence to pass to grid
     $scope.$watch(function() { return Variants.data.item; }, function(variant) {
       $scope.variant = variant;
       $scope.evidence = variant.evidence_items;

--- a/src/components/services/EvidenceRevisionsService.js
+++ b/src/components/services/EvidenceRevisionsService.js
@@ -260,7 +260,17 @@
     function submitRevision(reqObj) {
       return EvidenceRevisionsResource.submitRevision(reqObj).$promise.then(
         function(response) { // success
+
+          // flush evidence_item cache and refresh, in order to update the variant summary evidence grid
+          cache.remove('/api/variants/' + reqObj.variant_id);
+          Variants.get(reqObj.variant_id);
+
+          cache.remove('/api/variants/' + reqObj.variant_id + '/evidence_items');
+          Variants.queryEvidence(reqObj.variant_id);
+
+          // refresh suggested changes
           cache.remove('/api/evidence_items/' + reqObj.id + '/suggested_changes/');
+          query(reqObj.id);
 
           // flush gene variants and refresh (for variant menu)
           cache.remove('/api/genes/' + reqObj.gene_id + '/variants?count=999');
@@ -280,17 +290,23 @@
     function acceptRevision(evidenceId, revisionId, variantId) {
       return EvidenceRevisionsResource.acceptRevision({ evidenceId: evidenceId, revisionId: revisionId }).$promise.then(
         function(response) {
+
           // flush evidence_item cache and refresh, in order to update the variant summary evidence grid
           cache.remove('/api/variants/' + variantId);
+          Variants.get(variantId);
+
           cache.remove('/api/variants/' + variantId + '/evidence_items');
           Variants.queryEvidence(variantId);
+
           // refresh suggested changes
           cache.remove('/api/evidence_items/' + evidenceId + '/suggested_changes/');
           query(evidenceId);
+
           // refresh revision
           cache.remove('/api/evidence_items/' + evidenceId + '/suggested_changes/' + revisionId);
-          // refresh evidence item
           get(evidenceId, revisionId);
+
+          // refresh evidence item
           cache.remove('/api/evidence_items/' + evidenceId );
           Evidence.get(evidenceId);
 
@@ -308,11 +324,21 @@
           return $q.reject(error);
         });
     }
-    function rejectRevision(evidenceId, revisionId) {
+    function rejectRevision(evidenceId, revisionId, variantId) {
       return EvidenceRevisionsResource.rejectRevision({ evidenceId: evidenceId, revisionId: revisionId }).$promise.then(
         function(response) {
+          // flush evidence_item cache and refresh, in order to update the variant summary evidence grid
+          cache.remove('/api/variants/' + variantId);
+          Variants.get(variantId);
+
+          cache.remove('/api/variants/' + variantId + '/evidence_items');
+          Variants.queryEvidence(variantId);
+
+          // refresh suggested changes
           cache.remove('/api/evidence_items/' + response.id + '/suggested_changes/');
           query(evidenceId);
+
+          // refresh revision
           cache.remove('/api/evidence_items/' + response.id + '/suggested_changes/' + revisionId);
           get(evidenceId, revisionId);
 

--- a/src/components/services/EvidenceService.js
+++ b/src/components/services/EvidenceService.js
@@ -162,13 +162,15 @@
     function add(reqObj) {
       return EvidenceResource.add(reqObj).$promise
         .then(function(response) {
-          // flush cached variant and evidence item lists
+          // flush cached variant, variant groups, and evidence item lists
           cache.remove('/api/variants/' + response.variant.id);
           cache.remove('/api/variants/' + response.variant.id + '/evidence_items');
+          cache.remove('/api/genes/' + response.gene.id + '/variant_groups'); 
 
           // flush gene variants and refresh (for variant menu)
           cache.remove('/api/genes/' + reqObj.gene.id + '/variants?count=999');
           Genes.queryVariants(reqObj.gene.id);
+          Genes.queryVariantGroups(reqObj.gene.id)
 
           return response.$promise;
         });
@@ -180,12 +182,14 @@
           cache.remove('/api/evidence_items/' + response.id);
           cache.remove('/api/variants/' + variantId);
           cache.remove('/api/variants/' + variantId + '/evidence_items');
+          cache.remove('/api/genes/' + response.gene_id + '/variant_groups'); 
           get(response.id);
           Variants.get(variantId);
 
           // flush gene variants and refresh (for variant menu)
           cache.remove('/api/genes/' + response.gene_id + '/variants?count=999');
           Genes.queryVariants(response.gene_id);
+          Genes.queryVariantGroups(response.gene_id)
 
           return response.$promise;
         });
@@ -197,12 +201,14 @@
           cache.remove('/api/evidence_items/' + response.id);
           cache.remove('/api/variants/' + variantId);
           cache.remove('/api/variants/' + variantId + '/evidence_items');
+          cache.remove('/api/genes/' + response.gene_id + '/variant_groups'); 
           get(response.id);
           Variants.get(variantId);
 
           // flush gene variants and refresh (for variant menu)
           cache.remove('/api/genes/' + response.gene_id + '/variants?count=999');
           Genes.queryVariants(response.gene_id);
+          Genes.queryVariantGroups(response.gene_id);
 
           return response.$promise;
         });


### PR DESCRIPTION
Addresses #695. 

The watcher in variantSummary.js only was watching Variants.data.item, while the accept, reject, and submit revisions actions in EvidenceRevisionsService.js were not re-getting Variants.data.item after cache removal. 

Note: might be room to make things more efficient since it looks like the watcher is resetting $scope.evidence by copying Variants.data.item.evidence_items instead of Variants.data.evidence - and we query for both with Variants.get and Variants.queryEvidence - so seems like there's redundant information being fetched, at least in this case.