### PR TITLE
Added extra clause in ternary syntax

### DIFF
--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -4,7 +4,16 @@
       <div class="row">
         <div class="col-xs-12">
           <div ng-if="variant.variant_aliases.length > 0">
-            <p><strong>Aliases: </strong><span ng-repeat="alias in variant.variant_aliases">{{$first ? '' : $last ? ', and ' : ', '}}{{ alias }}</span></p>
+            <p><strong>Aliases: </strong>
+              <span ng-repeat="alias in variant.variant_aliases">
+                {{
+                  $first ? '' : $last ? (
+                    variant.variant_aliases.length > 2 ? ', and ' : ' and '
+                  ) : ', '
+                }}
+                {{ alias }}
+              </span>
+            </p>
           </div>
           <div ng-switch="variant.description.length > 0">
             <div ng-switch-when="true">
@@ -33,7 +42,19 @@
             <p>
               <strong>Variant Type<span ng-if="variant.variant_types.length > 1">s</span>:</strong><br/>
               <span ng-switch="variant.variant_types.length > 0">
-                <span ng-switch-when="true"><span ng-repeat="type in variant.variant_types">{{$first ? '' : $last ? ', and ' : ', '}}<span  ng-if="type.display_name !== 'N/A'"><a ng-href="{{ type.url }}" target="_blank">{{type.display_name}}</a></span><span ng-if="type.display_name === 'N/A'">{{type.display_name}}</span></span></span>
+                <span ng-switch-when="true">
+                  <span ng-repeat="type in variant.variant_types">
+                    {{
+                      $first ? '' : $last ? (
+                        variant.variant_types.length > 2 ? ', and ' : ' and '
+                      ) : ', '
+                    }}
+                    <span  ng-if="type.display_name !== 'N/A'">
+                      <a ng-href="{{ type.url }}" target="_blank">{{type.display_name}}</a>
+                    </span>
+                    <span ng-if="type.display_name === 'N/A'">{{type.display_name}}</span>
+                  </span>
+                </span>
                 <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
                   None specified.
                 </span>
@@ -46,7 +67,11 @@
               <span ng-switch="variant.hgvs_expressions.length > 0">
                 <span ng-switch-when="true">
                   <span ng-repeat="expression in variant.hgvs_expressions" class="small">
-                    {{$first ? '' : $last ? ', and ' : ', '}}
+                    {{
+                      $first ? '' : $last ? (
+                        variant.hgvs_expressions.length > 2 ? ', and ' : ' and '
+                      ) : ', '
+                    }}
                     {{ expression }}
                   </span>
                 </span>
@@ -62,7 +87,11 @@
               <span ng-switch="variant.clinvar_entries.length > 0">
                 <span ng-switch-when="true">
                   <span ng-repeat="clinvar_id in variant.clinvar_entries" class="small">
-                    {{$first ? '' : $last ? ', and ' : ', '}}
+                    {{
+                      $first ? '' : $last ? (
+                        variant.clinvar_entries.length > 2 ? ', and ' : ' and '
+                      ) : ', '
+                    }}
                     <a ng-if="clinvar_id !== 'N/A'" ng-href="https://www.ncbi.nlm.nih.gov/clinvar/variation/{{ clinvar_id }}/" target="_blank">{{ clinvar_id }}</a>
                     <span ng-if="clinvar_id == 'N/A'">{{ clinvar_id }}</span>
                   </span>


### PR DESCRIPTION
Variant summary page now demonstrates proper comma use when listing variant aliases, types, hgvs expressions, and clinvar ids

Tested [R140](https://civic.genome.wustl.edu/#/events/genes/27/summary/variants/62/summary) for clinvar IDs, [I1145I](https://civic.genome.wustl.edu/#/events/genes/4244/summary/variants/263/summary) for aliases, [F1174L](https://civic.genome.wustl.edu/#/events/genes/1/summary/variants/8/summary) for hgvs expressions, and [BCR-ABL T334I](https://civic.genome.wustl.edu/#/events/genes/4/summary/variants/2/summary) for variant types

closes #717 