### PR TITLE
Added custom filter to filter by submitter

### DIFF
--- a/src/app/views/sources/components/sourceSuggestionGrid.js
+++ b/src/app/views/sources/components/sourceSuggestionGrid.js
@@ -101,7 +101,12 @@
           allowCellFocus: false,
           type: 'string',
           filter: {
-            condition: uiGridConstants.filter.CONTAINS
+            // condition: uiGridConstants.filter.CONTAINS
+            condition: function(search, value, row, col)
+            {
+                var query = new RegExp(search, 'i');
+                return query.exec(value.username);
+            }
           },
           cellTemplate: '<div class="ui-grid-cell-contents"><user-block user="row.entity[col.field]"</div>',
         },

--- a/src/components/filters.js
+++ b/src/components/filters.js
@@ -22,9 +22,12 @@
   }
 
   // @ngInject
-  function highlightSearch(){
+  function highlightSearch(_){
     return function (input, query) {
-      return input.toString().replace(RegExp('('+ _.escapeRegExp(query)+ ')', 'gi'), '<strong>$1</strong>');
+      if(typeof input === "string")
+      return (typeof query === "string" && query.length > 0) ? input.toString().replace(
+        RegExp('('+ _.escapeRegExp(query)+ ')', 'gi'), '<strong>$1</strong>'
+      ) : input;
     }
   }
 


### PR DESCRIPTION
Added a custom filter to sort by usernames.  Previously, ui-grid was trying to cast the users to strings (which meant that all users were matched by '[object Object]' and its substrings only).

Closes #714 