### PR TITLE
Added control logic to highlighting filter

### DIFF
--- a/src/components/filters.js
+++ b/src/components/filters.js
@@ -22,9 +22,12 @@
   }
 
   // @ngInject
-  function highlightSearch(){
+  function highlightSearch(_){
     return function (input, query) {
-      return input.toString().replace(RegExp('('+ _.escapeRegExp(query)+ ')', 'gi'), '<strong>$1</strong>');
+      if(typeof input === "string")
+      return (typeof query === "string" && query.length > 0) ? input.toString().replace(
+        RegExp('('+ _.escapeRegExp(query)+ ')', 'gi'), '<strong>$1</strong>'
+      ) : input;
     }
   }
 


### PR DESCRIPTION
Now prevents the filter from running with an empty query or input
Previously, an empty filter lagged the grid by flooding the console with errors

This may not be enough of a performance gain, in which case, the best option is probably to roll back the original highlighting PR (or at least disable highlighting on the evidence grid)
Closes #711 