### PR TITLE
Switched to using cloudflare's cdn for serving all vendor libraries

### DIFF
--- a/gulp/cdnize.js
+++ b/gulp/cdnize.js
@@ -16,24 +16,26 @@ gulp.task('cdnize', ['wiredep'], function () {
       //including tests for missing individual angular modules
       {
         file: '**/angular/angular.js',
-        cdn: 'google:angular:${ filenameMin }'
+        package: 'angular',
+        // cdn: 'cdnjs:angular:${ filenameMin }'
+        cdn: '//cdnjs.cloudflare.com/ajax/libs/angular.js/${ version }/${ filenameMin }',
       },
       {
         file: '**/angular-sanitize/*.js',
         package: 'angular-sanitize',
-        cdn: 'google:angular:${ filenameMin }',
+        cdn: '//cdnjs.cloudflare.com/ajax/libs/angular.js/${ version }/${ filenameMin }',
         test: 'testModule("ngSanitize")'
       },
       {
         file: '**/angular-touch/*.js',
         package: 'angular-touch',
-        cdn: 'google:angular:${ filenameMin }',
+        cdn: '//cdnjs.cloudflare.com/ajax/libs/angular.js/${ version }/${ filenameMin }',
         test: 'testModule("ngTouch")'
       },
       {
         file: '**/angular-messages/*.js',
         package: 'angular-messages',
-        cdn: 'google:angular:${ filenameMin }',
+        cdn: '//cdnjs.cloudflare.com/ajax/libs/angular.js/${ version }/${ filenameMin }',
         test: 'testModule("ngMessages")'
       },
       {
@@ -90,7 +92,7 @@ gulp.task('cdnize', ['wiredep'], function () {
       {
         file: '**/angular-resource/*.js',
         package: 'angular-resource',
-        cdn: 'google:angular:${ filenameMin }',
+        cdn: '//cdnjs.cloudflare.com/ajax/libs/angular.js/${ version }/${ filenameMin }',
         test: 'testModule("ngResource")'
       },
       {


### PR DESCRIPTION
should help avoid problems getting through the GFW as pointed out in #728 

\*.googleapis.com appears to be blocked in mainland china, but cloudflare's cdnjs seems to work fine

GreatFire test results of the two CDNs:
* [Google's CDN](https://en.greatfire.org/ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular.min.js)
* [Cloudflare's CDN](https://en.greatfire.org/cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.7/angular.min.js)

closes #728 