### PR TITLE
Update help_evidence_types.tpl.html

### DIFF
--- a/src/app/pages/help_evidence_types.tpl.html
+++ b/src/app/pages/help_evidence_types.tpl.html
@@ -110,7 +110,7 @@
       <td>Refer to the <a href="http://www.nature.com/gim/journal/v17/n5/pdf/gim201530a.pdf" title="Nature.com ACMG Guidelines" target="_blank">ACMG Standards and Guidelines</a> for details.</td>
     </tr>
     <tr>
-      <td>Uncertain Significance: <br>The variant fullfill the ACMG criteria for pathogenic/benign, or the evidence is conflicting.</td>
+      <td>Uncertain Significance: <br>The variant does not fullfill the ACMG criteria for pathogenic/benign, or the evidence is conflicting.</td>
       <td>Refer to the <a href="http://www.nature.com/gim/journal/v17/n5/pdf/gim201530a.pdf" title="Nature.com ACMG Guidelines" target="_blank">ACMG Standards and Guidelines</a> for details.</td>
     </tr>
 


### PR DESCRIPTION
Predisposing evidence of uncertain significance text has a typo.