### PR TITLE
Revert "Secondary Gene Support for Variants"

### DIFF
--- a/src/app/views/events/variants/edit/variantEditBasic.js
+++ b/src/app/views/events/variants/edit/variantEditBasic.js
@@ -429,16 +429,6 @@
         }
       },
       {
-        model: vm.variantEdit.coordinates.secondary_gene,
-        key: 'name',
-        type: 'horizontalInputHelp',
-        templateOptions: {
-          label: 'Secondary Gene',
-          value: vm.variantEdit.coordinates.secondary_gene.id,
-          helpText: 'For fusion variants, a secondary gene may be specified.'
-        }
-      },
-      {
         template: '<hr/>'
       },
       {

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -208,26 +208,6 @@
             </tbody>
           </table>
         </div>
-        <div ng-if="variant.coordinates.secondary_gene">
-          <div class="section-title">
-            SECONDARY GENE
-          </div>
-          <table class="table table-condensed borderless">
-            <tbody class="common">
-              <tr>
-                <td class="key">
-                  Gene Name
-                </td>
-              <tr>
-                <td class="value">
-                  <a ng-href="#/events/genes/{{variant.coordinates.secondary_gene.id}}/summary">
-                      {{variant.coordinates.secondary_gene.name | ifEmpty: '--'}}
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
         <div ng-if="isAuthenticated() && !isEdit">
           <a class="btn btn-default btn-xs btn-block"
              ng-click="editClick()">Edit Coordinates</a>


### PR DESCRIPTION
Reverts genome/civic-client#622

Server support of the secondary gene feature was reverted, will re-merge later when server support exists on master.