### PR TITLE
update clinvar entry types

### DIFF
--- a/src/app/pages/help_variant_overview.tpl.html
+++ b/src/app/pages/help_variant_overview.tpl.html
@@ -65,7 +65,10 @@
         ClinVar ID
       </td>
       <td class="description">
-        User-defined ClinVar ID referencing this Variant which will be linked directly to ClinVar.
+        User-defined ClinVar ID referencing this Variant which will be linked directly to ClinVar. 
+        A value of "None Specified" indicates that the variant has not been evaluated for a ClinVar ID. 
+        A value of "None Found" indicates that an attempt was made to find a matching ClinVar Entry, but none exists.
+        A value of "N/A" indicates that a ClinVar record is not applicable to the variant (e.g. "Overexpression" variants).
       </td>
       <td class="source">
         CIViC (ClinVar)

--- a/src/app/views/events/variants/summary/variantSummary.js
+++ b/src/app/views/events/variants/summary/variantSummary.js
@@ -28,6 +28,8 @@
     $scope.variant = parseVariant(Variants.data.item);
     $scope.evidence = Variants.data.evidence;
 
+    $scope.clinvar_ignore = ['N/A', 'NONE FOUND']
+
     // watches any changes to the variant itself, but will also update evidence to pass to grid
     $scope.$watch(function() { return Variants.data.item; }, function(variant) {
       $scope.variant = variant;

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -92,8 +92,8 @@
                         variant.clinvar_entries.length > 2 ? ', and ' : ' and '
                       ) : ', '
                     }}
-                    <a ng-if="clinvar_id !== 'N/A'" ng-href="https://www.ncbi.nlm.nih.gov/clinvar/variation/{{ clinvar_id }}/" target="_blank">{{ clinvar_id }}</a>
-                    <span ng-if="clinvar_id == 'N/A'">{{ clinvar_id }}</span>
+                    <a ng-if="clinvar_ignore.indexOf(clinvar_id) == -1" ng-href="https://www.ncbi.nlm.nih.gov/clinvar/variation/{{ clinvar_id }}/" target="_blank">{{ clinvar_id }}</a>
+                    <span ng-if="clinvar_ignore.indexOf(clinvar_id) !== -1">{{ clinvar_id }}</span>
                   </span>
                 </span>
                 <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">


### PR DESCRIPTION
It would be nice to have form validation for clinvar entry (numeric or N/A or NONE FOUND), although that's beyond my current abilities with Angular.

This PR adds text to the help page explaining N/A, NONE FOUND, and NONE SPECIFIED, and fixes a small bug where NONE FOUND links out to clinvar (even though it shouldn't).