### PR TITLE
predisposing evidence now only allows N/A option for direction and significance fields

### DIFF
--- a/src/app/views/activity/directives/activityGrid.js
+++ b/src/app/views/activity/directives/activityGrid.js
@@ -319,7 +319,7 @@
           assertions:function(params) { return params.assertion.name; },
           genes: function(params){ return params.gene.name; },
           variants: function(params){ return params.variant.name; },
-          variantgroups: function(params){ return params.variantgroup.name; },
+          variantgroups: function(params){ return params.variant_group.name; },
           evidenceitems: function(params){ return params.evidence_item.name; },
           sources: function(params){ return params.source.name; },
           suggestedchanges: function(params){

--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -353,7 +353,7 @@
           helpText: 'Type of clinical outcome associated with the assertion description.',
           data: {
             attributeDefinition: '&nbsp;',
-            attributeDefinitions: descriptions.evidence_type
+            attributeDefinitions: descriptions.evidence_type.assertion
           }
         },
         watcher: {
@@ -396,13 +396,13 @@
           label: 'Assertion Direction',
           required: true,
           value: 'vm.newEvidence.evidence_direction',
-          ngOptions: 'option["value"] as option["label"] for option in to.options',
           options: [{ value: '', label: 'Please select an Assertion Direction' }].concat(make_options(descriptions.evidence_direction.assertion['Diagnostic'])), //dummy index e.g. 'Diagnostic'
           valueProp: 'value',
           labelProp: 'label',
-          helpText: 'An indicator of whether the evidence statement supports or refutes the clinical significance of an event. Assertion Type must be selected before this field is enabled.',
+          evidenceDirectionOptions: [{ type: 'default', value: '', label: 'Please select an Assertion Direction' }].concat(cs_options(descriptions.evidence_direction.assertion)),
+          helpText: 'An indicator of whether the assertion statement supports or refutes the clinical significance of an event. Assertion Type must be selected before this field is enabled.',
           data: {
-            attributeDefinition: '',
+            attributeDefinition: 'Please choose Assertion Type before selecting Assertion Direction.',
             attributeDefinitions: descriptions.evidence_direction.assertion,
             updateDefinition: function(value, options, scope) {
               // set attribute definition
@@ -415,6 +415,13 @@
           }
         },
         expressionProperties: {
+          'templateOptions.options': function($viewValue, $modelValue, scope) {
+            return  _.filter(scope.to.evidenceDirectionOptions, function(option) {
+              return !!(option.type === scope.model.evidence_type ||
+                        option.type === 'default' ||
+                        option.type === 'N/A');
+            });
+          },
           'templateOptions.disabled': 'model.evidence_type === ""' // deactivate if evidence_type unselected
         }
       },

--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -151,12 +151,14 @@
           listener: function(field, newValue, oldValue, scope) {
             // if gene is valid, remove the 'please specify gene...' message
             if(!_.isUndefined(field.formControl) && field.formControl.$valid) {
-              _.find(scope.fields, { key: 'variant'}).templateOptions.data.message = '';
+              var varField = _.find(scope.fields, { key: 'variant'});
+              varField.templateOptions.data.message = '';
             }
             // if gene is invalid, remove any defined variant and show 'pls specify gene' msg
             if(!_.isUndefined(field.formControl) && field.formControl.$invalid) {
               scope.model.variant = {name:''};
-              _.find(scope.fields, { key: 'variant'}).templateOptions.data.message = 'Please specify a gene before selecting a variant.';
+              var varField = _.find(scope.fields, { key: 'variant'});
+              varField.templateOptions.data.message = 'Please specify a gene before selecting a variant.';
             }
           }
         },
@@ -199,13 +201,12 @@
           typeaheadMinLength: 0,
           selectOnBlur: true,
           data: {
-            message: 'Please specify a Gene before choosing a Variant.'
+            message: 'Please specify a Gene before choosing a Variant.',
           }
         },
         expressionProperties: {
           'templateOptions.disabled': function($viewValue, $modelValue, scope) {
-            var geneField = _.find(scope.fields, { key: 'gene'});
-            return geneField.formControl.$invalid;
+            return scope.model.gene ? scope.model.gene.name == '': false;
           }
         },
         data: {

--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -377,7 +377,7 @@
             if($stateParams.evidenceType) {
               var et = $stateParams.evidenceType;
               var ed = $stateParams.evidenceDirection;
-              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_direction[et]);
+              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_direction.assertion[et]);
               if(_.includes(permitted, ed)) {
                 $scope.model.evidence_direction = $stateParams.evidenceDirection;
                 $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[et][ed];
@@ -395,13 +395,13 @@
           required: true,
           value: 'vm.newEvidence.evidence_direction',
           ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: [{ value: '', label: 'Please select an Assertion Direction' }].concat(make_options(descriptions.evidence_direction['Diagnostic'])), //dummy index e.g. 'Diagnostic'
+          options: [{ value: '', label: 'Please select an Assertion Direction' }].concat(make_options(descriptions.evidence_direction.assertion['Diagnostic'])), //dummy index e.g. 'Diagnostic'
           valueProp: 'value',
           labelProp: 'label',
           helpText: 'An indicator of whether the evidence statement supports or refutes the clinical significance of an event. Assertion Type must be selected before this field is enabled.',
           data: {
             attributeDefinition: '',
-            attributeDefinitions: descriptions.evidence_direction,
+            attributeDefinitions: descriptions.evidence_direction.assertion,
             updateDefinition: function(value, options, scope) {
               // set attribute definition
               options.templateOptions.data.attributeDefinition =
@@ -426,7 +426,7 @@
             if($stateParams.evidenceType) {
               var et = $stateParams.evidenceType;
               var cs = $stateParams.clinicalSignificance;
-              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.clinical_significance[et]);
+              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.clinical_significance.assertion[et]);
               if(_.includes(permitted, cs)) {
                 $scope.model.clinical_significance = $stateParams.clinicalSignificance;
                 $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[cs];
@@ -444,14 +444,14 @@
           required: true,
           value: 'vm.newEvidence.clinical_significance',
           // stores unmodified options array for expressionProperties
-          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance)),
+          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.assertion)),
           ngOptions: 'option["value"] as option["label"] for option in to.options',
           // actual options displayed in the select, modified by expressionProperties
-          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance)),
+          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.assertion)),
           helpText: 'Positive or negative association of the Variant with predictive, prognostic, diagnostic, or predisposing assertion types. If the variant was not associated with a positive or negative outcome, N/A should be selected. Assertion Type must be selected before this field is enabled.',
           data: {
             attributeDefinition: 'Please choose Assertion Type before selecting Clinical Significance.',
-            attributeDefinitions: merge_props(descriptions.clinical_significance),
+            attributeDefinitions: merge_props(descriptions.clinical_significance.assertion),
             updateDefinition: function(value, options, scope) {
               // set attribute definition
               options.templateOptions.data.attributeDefinition =

--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -329,8 +329,15 @@
           ngOptions: 'option["value"] as option["label"] for option in to.options',
           options: [{ value: '', label: 'Please select an Assertion Type' }].concat(make_options(descriptions.evidence_type.assertion)),
           onChange: function(value, options, scope) {
-            // reset clinical_significance, as its options will change
-            scope.model.clinical_significance = '';
+            // reset evidence_direction and clinical_significance, as their options will change
+            // also update $touched so user notices
+            var csField = _.find(scope.fields, { key: 'clinical_significance'});
+            var edField = _.find(scope.fields, { key: 'evidence_direction'});
+
+            csField.value('');
+            edField.value('');
+            csField.templateOptions.data.attributeDefinition = '';
+            edField.templateOptions.data.attributeDefinition = '';
 
             // if we're switching to Predictive, seed the drugs array w/ a blank entry,
             // otherwise set to empty array
@@ -338,12 +345,6 @@
 
             // set attribute definition
             options.templateOptions.data.attributeDefinition = options.templateOptions.data.attributeDefinitions[value];
-
-            // update evidence direction attribute definition
-            var edField = _.find(scope.fields, { key: 'evidence_direction'});
-            if (edField.value() !== '') { // only update if user has selected an option
-              edField.templateOptions.data.updateDefinition(null, edField, scope);
-            }
 
             // reset ACMG codes if new Type != Predisposing
             if(value !== 'Predisposing') {
@@ -593,14 +594,14 @@
           }
         },
         expressionProperties: {
-          isUnique: function (viewValue, modelValue, scope) {
-            var codes = _.without(modelValue, '');
-            if(_.uniq(codes).length < codes.length) {
-              scope.to.data.message = 'NOTE: Duplicate ACMG codes will be ignored.';
-            } else {
-              scope.to.data.message = '';
-            }
-          }
+          // isUnique: function (viewValue, modelValue, scope) {
+          //   var codes = _.without(modelValue, '');
+          //   if(_.uniq(codes).length < codes.length) {
+          //     scope.to.data.message = 'NOTE: Duplicate ACMG codes will be ignored.';
+          //   } else {
+          //     scope.to.data.message = '';
+          //   }
+          // }
         },
         hideExpression: function($viewValue, $modelValue, scope) {
           return  scope.model.evidence_type !== 'Predisposing';

--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -326,7 +326,7 @@
           required: true,
           value: 'vm.newEvidence.evidence_type',
           ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: _.filter([{ value: '', label: 'Please select an Assertion Type' }].concat(make_options(descriptions.evidence_type)), function(t) { return t.value !== 'Functional'; }),
+          options: [{ value: '', label: 'Please select an Assertion Type' }].concat(make_options(descriptions.evidence_type.assertion)),
           onChange: function(value, options, scope) {
             // reset clinical_significance, as its options will change
             scope.model.clinical_significance = '';

--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -249,6 +249,7 @@
           label: 'Variant Origin',
           value: 'vm.newEvidence.variant_origin',
           options: [{ value: '', label: 'Please select a Variant Origin' }].concat(make_options(descriptions.variant_origin)),
+          required: true,
           valueProp: 'value',
           labelProp: 'label',
           helpText: help['Variant Origin'],

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -499,7 +499,7 @@
           required: true,
           value: 'vm.newEvidence.evidence_type',
           ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type)),
+          options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type.evidence_item)),
           onChange: function(value, options, scope) {
             // reset evidence_direction and clinical_significance, as their options will change
             // also update $touched so user notices

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -501,8 +501,9 @@
           ngOptions: 'option["value"] as option["label"] for option in to.options',
           options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type)),
           onChange: function(value, options, scope) {
-            // reset clinical_significance, as its options will change
+            // reset evidence_direction and clinical_significance, as their options will change
             scope.model.clinical_significance = '';
+            scope.model.evidence_direction = '';
 
             // if we're switching to Predictive, seed the drugs array w/ a blank entry,
             // otherwise set to empty array
@@ -567,7 +568,7 @@
             if($stateParams.evidenceType) {
               var et = $stateParams.evidenceType;
               var ed = $stateParams.evidenceDirection;
-              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_direction[et]);
+              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_direction.evidence_item[et]);
               if(_.includes(permitted, ed)) {
                 $scope.model.evidence_direction = $stateParams.evidenceDirection;
                 $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[et][ed];
@@ -584,13 +585,14 @@
           label: 'Evidence Direction',
           required: true,
           value: 'vm.newEvidence.evidence_direction',
-          options: [{ value: '', label: 'Please select an Evidence Direction' }].concat(make_options(descriptions.evidence_direction['Diagnostic'])), //dummy index e.g. 'Diagnostic'
+          options: [{ value: '', label: 'Please select an Evidence Direction' }].concat(make_options(descriptions.evidence_direction.evidence_item['Diagnostic'])), //dummy index e.g. 'Diagnostic'
           valueProp: 'value',
           labelProp: 'label',
           helpText: help['Evidence Direction'],
+          evidenceDirectionOptions: [{ type: 'default', value: '', label: 'Please select an Evidence Direction' }].concat(cs_options(descriptions.evidence_direction.evidence_item)),
           data: {
             attributeDefinition: 'Please choose Evidence Type before selecting Evidence Direction.',
-            attributeDefinitions: descriptions.evidence_direction,
+            attributeDefinitions: descriptions.evidence_direction.evidence_item,
             updateDefinition: function(value, options, scope) {
               // set attribute definition
               options.templateOptions.data.attributeDefinition =
@@ -602,6 +604,13 @@
           }
         },
         expressionProperties: {
+          'templateOptions.options': function($viewValue, $modelValue, scope) {
+            return  _.filter(scope.to.evidenceDirectionOptions, function(option) {
+              return !!(option.type === scope.model.evidence_type ||
+                        option.type === 'default' ||
+                        option.type === 'N/A');
+            });
+          },
           'templateOptions.disabled': 'model.evidence_type === ""' // deactivate if evidence_type unselected
         }
       },
@@ -615,7 +624,7 @@
             if($stateParams.evidenceType) {
               var et = $stateParams.evidenceType;
               var cs = $stateParams.clinicalSignificance;
-              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.clinical_significance[et]);
+              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.clinical_significance.evidence_item[et]);
               if(_.includes(permitted, cs)) {
                 $scope.model.clinical_significance = $stateParams.clinicalSignificance;
                 $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[cs];
@@ -633,14 +642,14 @@
           required: true,
           value: 'vm.newEvidence.clinical_significance',
           // stores unmodified options array for expressionProperties
-          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance)),
+          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
           ngOptions: 'option["value"] as option["label"] for option in to.options',
           // actual options displayed in the select, modified by expressionProperties
-          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance)),
+          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
           helpText: help['Clinical Significance'],
           data: {
             attributeDefinition: 'Please choose Evidence Type before selecting Clinical Significance.',
-            attributeDefinitions: merge_props(descriptions.clinical_significance),
+            attributeDefinitions: merge_props(descriptions.clinical_significance.evidence_item),
             updateDefinition: function(value, options, scope) {
               // set attribute definition
               options.templateOptions.data.attributeDefinition =

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -502,8 +502,11 @@
           options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type)),
           onChange: function(value, options, scope) {
             // reset evidence_direction and clinical_significance, as their options will change
+            // also update $touched so user notices
             scope.model.clinical_significance = '';
             scope.model.evidence_direction = '';
+            _.find(scope.fields, { key: 'clinical_significance'}).formControl.$touched = true;
+            _.find(scope.fields, { key: 'evidence_direction'}).formControl.$touched = true;
 
             // if we're switching to Predictive, seed the drugs array w/ a blank entry,
             // otherwise set to empty array

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -521,7 +521,7 @@
           helpText: help['Evidence Type'],
           data: {
             attributeDefinition: '&nbsp;',
-            attributeDefinitions: descriptions.evidence_type
+            attributeDefinitions: descriptions.evidence_type.evidence_item
           }
         }
       },

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -503,10 +503,13 @@
           onChange: function(value, options, scope) {
             // reset evidence_direction and clinical_significance, as their options will change
             // also update $touched so user notices
-            scope.model.clinical_significance = '';
-            scope.model.evidence_direction = '';
-            _.find(scope.fields, { key: 'clinical_significance'}).formControl.$touched = true;
-            _.find(scope.fields, { key: 'evidence_direction'}).formControl.$touched = true;
+            var csField = _.find(scope.fields, { key: 'clinical_significance'});
+            var edField = _.find(scope.fields, { key: 'evidence_direction'});
+
+            csField.value('');
+            edField.value('');
+            csField.templateOptions.data.attributeDefinition = '';
+            edField.templateOptions.data.attributeDefinition = '';
 
             // if we're switching to Predictive, seed the drugs array w/ a blank entry,
             // otherwise set to empty array
@@ -514,12 +517,6 @@
 
             // set attribute definition
             options.templateOptions.data.attributeDefinition = options.templateOptions.data.attributeDefinitions[value];
-
-            // update evidence direction attribute definition
-            var edField = _.find(scope.fields, { key: 'evidence_direction'});
-            if (edField.value() !== '') { // only update if user has selected an option
-              edField.templateOptions.data.updateDefinition(null, edField, scope);
-            }
           },
           helpText: help['Evidence Type'],
           data: {

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -458,7 +458,8 @@
             selectOptions: [
               { value: null, label: '--' },
               { value: 'Supports', label: 'Supports' },
-              { value: 'Does Not Support', label: 'Does not Support' }
+              { value: 'Does Not Support', label: 'Does not Support' },
+              { value: 'NA', label: 'NA' }
             ]
           },
           width: '6%',

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -459,7 +459,7 @@
               { value: null, label: '--' },
               { value: 'Supports', label: 'Supports' },
               { value: 'Does Not Support', label: 'Does not Support' },
-              { value: 'NA', label: 'NA' }
+              { value: 'N/A', label: 'N/A' }
             ]
           },
           width: '6%',

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -352,7 +352,7 @@
           helpText: 'Type of clinical outcome associated with the assertion description.',
           data: {
             attributeDefinition: '&nbsp;',
-            attributeDefinitions: descriptions.evidence_type
+            attributeDefinitions: descriptions.evidence_type.assertion
           }
         },
         watcher: {
@@ -399,6 +399,7 @@
           options: [{ value: '', label: 'Please select an Assertion Direction' }].concat(make_options(descriptions.evidence_direction.assertion['Diagnostic'])), //dummy index e.g. 'Diagnostic'
           valueProp: 'value',
           labelProp: 'label',
+          evidenceDirectionOptions: [{ type: 'default', value: '', label: 'Please select an Assertion Direction' }].concat(cs_options(descriptions.evidence_direction.assertion)),
           helpText: 'An indicator of whether the evidence statement supports or refutes the clinical significance of an event. Assertion Type must be selected before this field is enabled.',
           data: {
             attributeDefinition: '',
@@ -414,6 +415,13 @@
           }
         },
         expressionProperties: {
+          'templateOptions.options': function($viewValue, $modelValue, scope) {
+            return  _.filter(scope.to.evidenceDirectionOptions, function(option) {
+              return !!(option.type === scope.model.evidence_type ||
+                        option.type === 'default' ||
+                        option.type === 'N/A');
+            });
+          },
           'templateOptions.disabled': 'model.evidence_type === ""' // deactivate if evidence_type unselected
         }
       },
@@ -624,14 +632,14 @@
           }
         },
         expressionProperties: {
-          isUnique: function (viewValue, modelValue, scope) {
-            var codes = _.without(modelValue, '');
-            if(_.uniq(codes).length < codes.length) {
-              scope.to.data.message = 'NOTE: Duplicate ACMG codes will be ignored.';
-            } else {
-              scope.to.data.message = '';
-            }
-          }
+          // isUnique: function (viewValue, modelValue, scope) {
+          //   var codes = _.without(modelValue, '');
+          //   if(_.uniq(codes).length < codes.length) {
+          //     scope.to.data.message = 'NOTE: Duplicate ACMG codes will be ignored.';
+          //   } else {
+          //     scope.to.data.message = '';
+          //   }
+          // }
         },
         hideExpression: function($viewValue, $modelValue, scope) {
           return  scope.model.evidence_type !== 'Predisposing';

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -249,6 +249,7 @@
           label: 'Variant Origin',
           value: 'vm.newEvidence.variant_origin',
           options: [{ value: '', label: 'Please select a Variant Origin' }].concat(make_options(descriptions.variant_origin)),
+          required: true,
           valueProp: 'value',
           labelProp: 'label',
           helpText: help['Variant Origin'],

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -378,7 +378,7 @@
             if($stateParams.evidenceType) {
               var et = $stateParams.evidenceType;
               var ed = $stateParams.evidenceDirection;
-              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_direction[et]);
+              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_direction.assertion[et]);
               if(_.includes(permitted, ed)) {
                 $scope.model.evidence_direction = $stateParams.evidenceDirection;
                 $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[et][ed];
@@ -396,13 +396,13 @@
           required: true,
           value: 'vm.newEvidence.evidence_direction',
           ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: [{ value: '', label: 'Please select an Assertion Direction' }].concat(make_options(descriptions.evidence_direction['Diagnostic'])), //dummy index e.g. 'Diagnostic'
+          options: [{ value: '', label: 'Please select an Assertion Direction' }].concat(make_options(descriptions.evidence_direction.assertion['Diagnostic'])), //dummy index e.g. 'Diagnostic'
           valueProp: 'value',
           labelProp: 'label',
           helpText: 'An indicator of whether the evidence statement supports or refutes the clinical significance of an event. Assertion Type must be selected before this field is enabled.',
           data: {
             attributeDefinition: '',
-            attributeDefinitions: descriptions.evidence_direction,
+            attributeDefinitions: descriptions.evidence_direction.assertion,
             updateDefinition: function(value, options, scope) {
               // set attribute definition
               options.templateOptions.data.attributeDefinition =
@@ -427,7 +427,7 @@
             if($stateParams.evidenceType) {
               var et = $stateParams.evidenceType;
               var cs = $stateParams.clinicalSignificance;
-              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.clinical_significance[et]);
+              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.clinical_significance.assertion[et]);
               if(_.includes(permitted, cs)) {
                 $scope.model.clinical_significance = $stateParams.clinicalSignificance;
                 $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[cs];
@@ -445,14 +445,14 @@
           required: true,
           value: 'vm.newEvidence.clinical_significance',
           // stores unmodified options array for expressionProperties
-          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance)),
+          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.assertion)),
           ngOptions: 'option["value"] as option["label"] for option in to.options',
           // actual options displayed in the select, modified by expressionProperties
-          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance)),
+          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.assertion)),
           helpText: 'Positive or negative association of the Variant with predictive, prognostic, diagnostic, or predisposing assertion types. If the variant was not associated with a positive or negative outcome, N/A should be selected. Assertion Type must be selected before this field is enabled.',
           data: {
             attributeDefinition: 'Please choose Assertion Type before selecting Clinical Significance.',
-            attributeDefinitions: merge_props(descriptions.clinical_significance),
+            attributeDefinitions: merge_props(descriptions.clinical_significance.assertion),
             updateDefinition: function(value, options, scope) {
               // set attribute definition
               options.templateOptions.data.attributeDefinition =

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -311,7 +311,7 @@
         controller: /* @ngInject */ function($scope, $stateParams, ConfigService, _) {
           if($stateParams.evidenceType) {
             var et = $stateParams.evidenceType;
-            var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_type);
+            var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_type.assertion);
             if(_.includes(permitted, et)) {
               $scope.model.evidence_type = $stateParams.evidenceType;
               $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[et];
@@ -325,7 +325,7 @@
           required: true,
           value: 'vm.newEvidence.evidence_type',
           ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: _.filter([{ value: '', label: 'Please select an Assertion Type' }].concat(make_options(descriptions.evidence_type)), function(t) { return t.value !== 'Functional'; }),
+          options: [{ value: '', label: 'Please select an Assertion Type' }].concat(make_options(descriptions.evidence_type.assertion)),
           onChange: function(value, options, scope) {
             // reset clinical_significance, as its options will change
             scope.model.clinical_significance = '';

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -205,8 +205,7 @@
         },
         expressionProperties: {
           'templateOptions.disabled': function($viewValue, $modelValue, scope) {
-            var geneField = _.find(scope.fields, { key: 'gene'});
-            return geneField.formControl.$invalid;
+            return scope.model.gene ? scope.model.gene.name == '': false;
           }
         },
         data: {

--- a/src/app/views/events/assertions/edit/assertionEdit.tpl.html
+++ b/src/app/views/events/assertions/edit/assertionEdit.tpl.html
@@ -101,8 +101,8 @@
   <!-- <pre ng-bind="vm.assertion | json"></pre> -->
   <!-- </div> -->
   <!-- <div class="col-xs-6"> -->
-  <!-- <h4>vm.form</h4> -->
-  <!-- <pre ng-bind="vm.form | json"></pre> -->
+  <!-- <h4>vm.assertionFields</h4> -->
+  <!-- <pre ng-bind="vm.assertionFields | json"></pre> -->
   <!-- </div> -->
   <!-- </div> -->
 </div>

--- a/src/app/views/events/assertions/edit/assertionEdit.tpl.html
+++ b/src/app/views/events/assertions/edit/assertionEdit.tpl.html
@@ -43,10 +43,9 @@
   <div ng-if="vm.showForm">
     <div class="row edit-form">
       <div class="col-xs-12">
-        <form class="form-horizontal" autocomplete="off">
+        <form class="form-horizontal" name="vm.form" autocomplete="off">
           <formly-form options="vm.options" model="vm.assertionEdit" fields="vm.assertionFields">
           </formly-form>
-
         </form>
       </div>
     </div>
@@ -57,9 +56,12 @@
             <cancel-button></cancel-button>
           </div>
           <div class="pull-right">
-            <div ng-if="vm.isAuthenticated">
-              <button type="submit" class="btn btn-default" ng-click="vm.submit(vm.assertionEdit, vm.options)">Submit Revision for Review</button>
-            </div>
+            <button type="submit"
+              class="btn btn-default"
+              ng-disabled="vm.form.$invalid || vm.isAuthenticated === false"
+              ng-click="vm.submit(vm.assertionEdit, vm.options)">
+              Submit Revision for Review
+            </button>
           </div>
         </div>
       </div>
@@ -94,8 +96,13 @@
     </div>
   </div>
   <!-- <div class="row"> -->
-  <!-- <div class="col-xs-12"> -->
-  <!-- <pre ng-bind="vm.assertionEdit|json"></pre> -->
+  <!-- <div class="col-xs-6"> -->
+  <!-- <h4>Assertion</h4> -->
+  <!-- <pre ng-bind="vm.assertion | json"></pre> -->
+  <!-- </div> -->
+  <!-- <div class="col-xs-6"> -->
+  <!-- <h4>vm.form</h4> -->
+  <!-- <pre ng-bind="vm.form | json"></pre> -->
   <!-- </div> -->
   <!-- </div> -->
 </div>

--- a/src/app/views/events/common/evidenceDirectionCell.tpl.html
+++ b/src/app/views/events/common/evidenceDirectionCell.tpl.html
@@ -8,6 +8,6 @@
     class="glyphicon"
     ng-class="{ 'glyphicon-thumbs-up': row.entity[col.field] === 'Supports',
     'glyphicon-thumbs-down': row.entity[col.field] === 'Does Not Support',
-    'glyphicon-remove-circle not-applicable': row.entity[col.field] === 'NA' }">
+    'glyphicon-remove-circle not-applicable': row.entity[col.field] === 'N/A' }">
   </span>
 </div>

--- a/src/app/views/events/common/evidenceDirectionCell.tpl.html
+++ b/src/app/views/events/common/evidenceDirectionCell.tpl.html
@@ -6,6 +6,8 @@
      tooltip-append-to-body="true">
   <span
     class="glyphicon"
-    ng-class="{ 'glyphicon-thumbs-up': row.entity[col.field] === 'Supports', 'glyphicon-thumbs-down': row.entity[col.field] === 'Does Not Support'}">
+    ng-class="{ 'glyphicon-thumbs-up': row.entity[col.field] === 'Supports',
+    'glyphicon-thumbs-down': row.entity[col.field] === 'Does Not Support',
+    'glyphicon-remove-circle not-applicable': row.entity[col.field] === 'NA' }">
   </span>
 </div>

--- a/src/app/views/events/common/evidenceGrid.js
+++ b/src/app/views/events/common/evidenceGrid.js
@@ -303,7 +303,7 @@
               { value: null, label: '--' },
               { value: 'Supports', label: 'Supports' },
               { value: 'Does not Support', label: 'Does not Support' },
-              { value: 'NA', label: 'NA' }
+              { value: 'N/A', label: 'N/A' }
             ]
           },
           width: '6%',

--- a/src/app/views/events/common/evidenceGrid.js
+++ b/src/app/views/events/common/evidenceGrid.js
@@ -302,7 +302,8 @@
             selectOptions: [
               { value: null, label: '--' },
               { value: 'Supports', label: 'Supports' },
-              { value: 'Does not Support', label: 'Does not Support' }
+              { value: 'Does not Support', label: 'Does not Support' },
+              { value: 'NA', label: 'NA' }
             ]
           },
           width: '6%',

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -314,9 +314,12 @@
           ngOptions: 'option["value"] as option["label"] for option in to.options',
           options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type)),
           onChange: function(value, options, scope) {
-            // reset clinical_significance, as its options will change then update $touched to ensure user notices
+            // reset clinical_significance, as its options will change
+            // then update $touched to ensure user notices
             scope.model.clinical_significance = '';
+            scope.model.evidence_direction = '';
             _.find(scope.fields, { key: 'clinical_significance'}).formControl.$touched = true;
+            _.find(scope.fields, { key: 'evidence_direction'}).formControl.$touched = true;
 
             // if we're switching to Predictive, seed the drugs array w/ a blank entry,
             // otherwise set to empty array
@@ -378,13 +381,14 @@
           label: 'Evidence Direction',
           required: true,
           value: 'vm.evidenceEdit.evidence_direction',
-          options: [{ value: '', label: 'Please select an Evidence Direction' }].concat(make_options(descriptions.evidence_direction['Diagnostic'])),
+          options: [{ value: '', label: 'Please select an Evidence Direction' }].concat(make_options(descriptions.evidence_direction.evidence_item['Diagnostic'])),
           valueProp: 'value',
           labelProp: 'label',
           helpText: help['Evidence Direction'],
+          evidenceDirectionOptions: [{ type: 'default', value: '', label: 'Please select an Evidence Direction' }].concat(cs_options(descriptions.evidence_direction.evidence_item)),
           data: {
             attributeDefinition: '&nbsp;',
-            attributeDefinitions: descriptions.evidence_direction,
+            attributeDefinitions: descriptions.evidence_direction.evidence_item,
             updateDefinition: function(value, options, scope) {
               // set attribute definition
               options.templateOptions.data.attributeDefinition =
@@ -396,6 +400,11 @@
           }
         },
         expressionProperties:{
+          'templateOptions.options': function($viewValue, $modelValue, scope) {
+            return  _.filter(scope.to.evidenceDirectionOptions, function(option) {
+              return !!(option.type === scope.model.evidence_type || option.type === 'default' || option.type === 'N/A');
+            });
+          },
           'templateOptions.disabled': 'model.evidence_type === ""' // deactivate if evidence_type unselected
         }
       },
@@ -412,13 +421,13 @@
           label: 'Clinical Significance',
           required: true,
           value: 'vm.evidenceEdit.clinical_significance',
-          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance)),
+          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
           ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance)),
+          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
           helpText: help['Clinical Significance'],
           data: {
             attributeDefinition: '&nbsp;',
-            attributeDefinitions: descriptions.clinical_significance,
+            attributeDefinitions: descriptions.clinical_significance.evidence_item,
             updateDefinition: function(value, options, scope) {
               // set attribute definition
               options.templateOptions.data.attributeDefinition =

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -316,10 +316,13 @@
           onChange: function(value, options, scope) {
             // reset clinical_significance, as its options will change
             // then update $touched to ensure user notices
-            scope.model.clinical_significance = '';
-            scope.model.evidence_direction = '';
-            _.find(scope.fields, { key: 'clinical_significance'}).formControl.$touched = true;
-            _.find(scope.fields, { key: 'evidence_direction'}).formControl.$touched = true;
+            var csField = _.find(scope.fields, { key: 'clinical_significance'});
+            var edField = _.find(scope.fields, { key: 'evidence_direction'});
+
+            csField.value('');
+            edField.value('');
+            csField.templateOptions.data.attributeDefinition = '';
+            edField.templateOptions.data.attributeDefinition = '';
 
             // if we're switching to Predictive, seed the drugs array w/ a blank entry,
             // otherwise set to empty array
@@ -328,11 +331,6 @@
             // set attribute definition
             options.templateOptions.data.attributeDefinition = options.templateOptions.data.attributeDefinitions[value];
 
-            // update evidence direction attribute definition
-            var edField = _.find(scope.fields, { key: 'evidence_direction'});
-            if (edField.value() !== '') { // only update if user has selected an option
-              edField.templateOptions.data.updateDefinition(null, edField, scope);
-            }
           },
           helpText: help['Evidence Type'],
           data: {

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -312,7 +312,7 @@
           required: true,
           value: 'vm.evidenceEdit.evidence_type',
           ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type)),
+          options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type.evidence_item)),
           onChange: function(value, options, scope) {
             // reset clinical_significance, as its options will change
             // then update $touched to ensure user notices

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -27,7 +27,7 @@
           <td class="name">Evidence Type:</td>
           <td class="value">
             <span ng-bind="evidence.evidence_type"
-              uib-tooltip="{{tipText.evidence_type[evidence.evidence_type]}}"
+              uib-tooltip="{{tipText.evidence_type.evidence_item[evidence.evidence_type]}}"
               tooltip-placement="right"
               class="help-tooltip">
               evidence type</span>
@@ -37,7 +37,7 @@
           <td class="name">Evidence Direction:</td>
           <td class="value">
             <span ng-bind="evidence.evidence_direction"
-              uib-tooltip="{{tipText.evidence_direction[evidence.evidence_type][evidence.evidence_direction]}}"
+              uib-tooltip="{{tipText.evidence_direction.evidence_item[evidence.evidence_type][evidence.evidence_direction]}}"
               tooltip-placement="right"
               class="help-tooltip">
               evidence.evidence_direction
@@ -49,7 +49,7 @@
           <td class="name">Clinical Significance:</td>
           <td class="value">
             <span ng-bind="evidence.clinical_significance"
-              uib-tooltip="{{tipText.clinical_significance[evidence.evidence_type][evidence.clinical_significance]}}"
+              uib-tooltip="{{tipText.clinical_significance.evidence_item[evidence.evidence_type][evidence.clinical_significance]}}"
               tooltip-placement="right"
               class="help-tooltip"
               class="help-tooltip">

--- a/src/app/views/search/config/EvidenceItemFieldConfig.js
+++ b/src/app/views/search/config/EvidenceItemFieldConfig.js
@@ -634,7 +634,7 @@
                   options: [
                     { value: 'Supports', name: 'Supports'},
                     { value: 'Does Not Support', name: 'Does Not Support' },
-                    { value: 'NA', name: 'NA' }
+                    { value: 'N/A', name: 'N/A' }
                   ]
                 }
               }

--- a/src/app/views/search/config/EvidenceItemFieldConfig.js
+++ b/src/app/views/search/config/EvidenceItemFieldConfig.js
@@ -633,7 +633,8 @@
                   required: true,
                   options: [
                     { value: 'Supports', name: 'Supports'},
-                    { value: 'Does Not Support', name: 'Does Not Support' }
+                    { value: 'Does Not Support', name: 'Does Not Support' },
+                    { value: 'NA', name: 'NA' }
                   ]
                 }
               }

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -341,7 +341,7 @@
               'Does Not Support': 'The experiment or study does not support a prognostic association between variant and outcome'
             },
             'Predisposing': {
-              'N/A': 'Evidence Direction is Not Applicable for Predisposing Evidence Type'
+              'NA': 'Evidence Direction is Not Applicable for Predisposing Evidence Type. Due to technical limitations, this value must be stored as \'NA\' instead of \'N/A\'.'
             },
             'Functional': {
               'Support': 'TBD',

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -370,8 +370,7 @@
               'Does Not Support': 'The experiment or study does not support a prognostic association between variant and outcome'
             },
             'Predisposing': {
-              'Supports': 'The experiment or study supports a variant\'s impact on predisposing outcome',
-              'Does Not Support': 'The experiment or study does not support a predisposing association between variant and outcome'
+              'N/A': 'Evidence Direction is Not Applicable for Predisposing Assertion Type.'
             },
             'Functional': {
               'Support': 'TBD',
@@ -426,11 +425,7 @@
               'N/A': 'Variant does not inform clinical action'
             },
             'Predisposing': {
-              'Pathogenic': 'Very strong evidence the variant is pathogenic',
-              'Likely Pathogenic': 'Strong evidence (>90% certainty) the variant is pathogenic.',
-              'Benign': 'Very strong evidence the variant is benign',
-              'Likely Benign': 'Not expected to have a major effect on disease',
-              'Uncertain Significance': 'Does not fullfill the ACMG criteria for pathogenic/benign, or the evidence is conflicting',
+              'N/A': 'Clinical Significance is Not Applicable for Predisposing Assertion Type'
             },
             'Functional': {
               'Gain of Function': 'A sequence variant whereby new or enhanced function is conferred on the gene product',

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -329,7 +329,8 @@
         evidence_direction:{
           evidence_item: {
             'Predictive': {
-              'N/A': 'Evidence Direction is Not Applicable for Predictive Evidence Type'
+              'Supports': 'The experiment or study supports this variant\'s response to a drug',
+              'Does Not Support': 'The experiment or study does not support, or was inconclusive of an interaction between this variant and a drug'
             },
             'Diagnostic': {
               'Supports': 'The experiment or study supports this variant\'s impact on the diagnosis of disease or subtype',
@@ -340,8 +341,7 @@
               'Does Not Support': 'The experiment or study does not support a prognostic association between variant and outcome'
             },
             'Predisposing': {
-              'Supports': 'The experiment or study supports a variant\'s impact on predisposing outcome',
-              'Does Not Support': 'The experiment or study does not support a predisposing association between variant and outcome'
+              'N/A': 'Evidence Direction is Not Applicable for Predisposing Evidence Type'
             },
             'Functional': {
               'Support': 'TBD',
@@ -374,7 +374,11 @@
         clinical_significance: {
           evidence_item: {
             'Predictive': {
-              'N/A': 'Clinical Significance is Not Applicable for Predictive Evidence Type'
+              'Sensitivity/Response': 'Associated with a clinical or preclinical response to treatment',
+              'Resistance': 'Associated with clinical or preclinical resistance to treatment',
+              'Adverse Response': 'Associated with an adverse response to drug treatment',
+              'Reduced Sensitivity': 'Response to treatment is lower than seen in other treatment contexts',
+              'N/A': 'Variant does not inform clinical action'
             },
             'Diagnostic': {
               'Positive': 'Associated with diagnosis of disease or subtype',
@@ -386,11 +390,7 @@
               'N/A': 'Variant does not inform clinical action'
             },
             'Predisposing': {
-              'Pathogenic': 'Very strong evidence the variant is pathogenic',
-              'Likely Pathogenic': 'Strong evidence (>90% certainty) the variant is pathogenic.',
-              'Benign': 'Very strong evidence the variant is benign',
-              'Likely Benign': 'Not expected to have a major effect on disease',
-              'Uncertain Significance': 'Does not fullfill the ACMG criteria for pathogenic/benign, or the evidence is conflicting',
+              'N/A': 'Clinical Significance is Not Applicable for Predisposing Evidence Type'
             },
             'Functional': {
               'Gain of Function': 'A sequence variant whereby new or enhanced function is conferred on the gene product',

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -306,11 +306,19 @@
           'ASCO': 'Evidence item source uses an ASCO abstract.'
         },
         evidence_type: {
-          'Predictive': 'Evidence pertains to a variant\'s effect on therapeutic response',
-          'Diagnostic': 'Evidence pertains to a variant\'s impact on patient diagnosis (cancer subtype)',
-          'Prognostic': 'Evidence pertains to a variant\'s impact on disease progression, severity, or patient survival',
-          'Predisposing': 'Evidence pertains to a variant\'s role in conferring susceptibility to a disease',
-          'Functional': 'Evidence pertains to a variant that alters biological function from the reference state',
+          evidence_item: {
+            'Predictive': 'Evidence pertains to a variant\'s effect on therapeutic response',
+            'Diagnostic': 'Evidence pertains to a variant\'s impact on patient diagnosis (cancer subtype)',
+            'Prognostic': 'Evidence pertains to a variant\'s impact on disease progression, severity, or patient survival',
+            'Predisposing': 'Evidence pertains to a variant\'s role in conferring susceptibility to a disease',
+            'Functional': 'Evidence pertains to a variant that alters biological function from the reference state',
+          },
+          assertion: {
+            'Predictive': 'Evidence pertains to a variant\'s effect on therapeutic response',
+            'Diagnostic': 'Evidence pertains to a variant\'s impact on patient diagnosis (cancer subtype)',
+            'Prognostic': 'Evidence pertains to a variant\'s impact on disease progression, severity, or patient survival',
+            'Predisposing': 'Evidence pertains to a variant\'s role in conferring susceptibility to a disease',
+          }
         },
         evidence_level_brief: {
           A: 'Validated association',

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -349,7 +349,7 @@
               'Does Not Support': 'The experiment or study does not support a prognostic association between variant and outcome'
             },
             'Predisposing': {
-              'NA': 'Evidence Direction is Not Applicable for Predisposing Evidence Type. Due to technical limitations, this value must be stored as \'NA\' instead of \'N/A\'.'
+              'N/A': 'Evidence Direction is Not Applicable for Predisposing Evidence Type.'
             },
             'Functional': {
               'Support': 'TBD',

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -327,58 +327,111 @@
           E: 'Indirect evidence'
         },
         evidence_direction:{
-          'Predictive': {
-            'Supports': 'The experiment or study supports this variant\'s response to a drug',
-            'Does Not Support': 'The experiment or study does not support, or was inconclusive of an interaction between this variant and a drug'
+          evidence_item: {
+            'Predictive': {
+              'N/A': 'Evidence Direction is Not Applicable for Predictive Evidence Type'
+            },
+            'Diagnostic': {
+              'Supports': 'The experiment or study supports this variant\'s impact on the diagnosis of disease or subtype',
+              'Does Not Support': 'The experiment or study does not support this variant\'s impact on diagnosis of disease or subtype'
+            },
+            'Prognostic': {
+              'Supports': 'The experiment or study supports this variant\'s impact on prognostic outcome',
+              'Does Not Support': 'The experiment or study does not support a prognostic association between variant and outcome'
+            },
+            'Predisposing': {
+              'Supports': 'The experiment or study supports a variant\'s impact on predisposing outcome',
+              'Does Not Support': 'The experiment or study does not support a predisposing association between variant and outcome'
+            },
+            'Functional': {
+              'Support': 'TBD',
+              'Does Not Support': 'TBD',
+            },
           },
-          'Diagnostic': {
-            'Supports': 'The experiment or study supports this variant\'s impact on the diagnosis of disease or subtype',
-            'Does Not Support': 'The experiment or study does not support this variant\'s impact on diagnosis of disease or subtype'
-          },
-          'Prognostic': {
-            'Supports': 'The experiment or study supports this variant\'s impact on prognostic outcome',
-            'Does Not Support': 'The experiment or study does not support a prognostic association between variant and outcome'
-          },
-          'Predisposing': {
-            'Supports': 'The experiment or study supports a variant\'s impact on predisposing outcome',
-            'Does Not Support': 'The experiment or study does not support a predisposing association between variant and outcome'
-          },
-          'Functional': {
-            'Support': 'TBD',
-            'Does Not Support': 'TBD',
-          },
+          assertion: {
+            'Predictive': {
+              'Supports': 'The experiment or study supports this variant\'s response to a drug',
+              'Does Not Support': 'The experiment or study does not support, or was inconclusive of an interaction between this variant and a drug'
+            },
+            'Diagnostic': {
+              'Supports': 'The experiment or study supports this variant\'s impact on the diagnosis of disease or subtype',
+              'Does Not Support': 'The experiment or study does not support this variant\'s impact on diagnosis of disease or subtype'
+            },
+            'Prognostic': {
+              'Supports': 'The experiment or study supports this variant\'s impact on prognostic outcome',
+              'Does Not Support': 'The experiment or study does not support a prognostic association between variant and outcome'
+            },
+            'Predisposing': {
+              'Supports': 'The experiment or study supports a variant\'s impact on predisposing outcome',
+              'Does Not Support': 'The experiment or study does not support a predisposing association between variant and outcome'
+            },
+            'Functional': {
+              'Support': 'TBD',
+              'Does Not Support': 'TBD',
+            },
+          }
         },
         clinical_significance: {
-          'Predictive': {
-            'Sensitivity/Response': 'Associated with a clinical or preclinical response to treatment',
-            'Resistance': 'Associated with clinical or preclinical resistance to treatment',
-            'Adverse Response': 'Associated with an adverse response to drug treatment',
-            'Reduced Sensitivity': 'Response to treatment is lower than seen in other treatment contexts',
-            'N/A': 'Variant does not inform clinical action'
+          evidence_item: {
+            'Predictive': {
+              'N/A': 'Clinical Significance is Not Applicable for Predictive Evidence Type'
+            },
+            'Diagnostic': {
+              'Positive': 'Associated with diagnosis of disease or subtype',
+              'Negative': 'Associated with lack of disease or subtype',
+            },
+            'Prognostic': {
+              'Better Outcome': 'Demonstrates better than expected clinical outcome',
+              'Poor Outcome': 'Demonstrates worse than expected clinical outcome',
+              'N/A': 'Variant does not inform clinical action'
+            },
+            'Predisposing': {
+              'Pathogenic': 'Very strong evidence the variant is pathogenic',
+              'Likely Pathogenic': 'Strong evidence (>90% certainty) the variant is pathogenic.',
+              'Benign': 'Very strong evidence the variant is benign',
+              'Likely Benign': 'Not expected to have a major effect on disease',
+              'Uncertain Significance': 'Does not fullfill the ACMG criteria for pathogenic/benign, or the evidence is conflicting',
+            },
+            'Functional': {
+              'Gain of Function': 'A sequence variant whereby new or enhanced function is conferred on the gene product',
+              'Loss of Function': 'A sequence variant whereby the gene product has diminished or abolished function',
+              'Unaltered Function': 'A sequence variant whereby the function of the gene product is unchanged',
+              'Neomorphic': 'TBD',
+              'Unknown': 'A functional variant that cannot be precisely defined by gain-of-function, loss-of-function, or unaltered function',
+            },
           },
-          'Diagnostic': {
-            'Positive': 'Associated with diagnosis of disease or subtype',
-            'Negative': 'Associated with lack of disease or subtype',
-          },
-          'Prognostic': {
-            'Better Outcome': 'Demonstrates better than expected clinical outcome',
-            'Poor Outcome': 'Demonstrates worse than expected clinical outcome',
-            'N/A': 'Variant does not inform clinical action'
-          },
-          'Predisposing': {
-            'Pathogenic': 'Very strong evidence the variant is pathogenic',
-            'Likely Pathogenic': 'Strong evidence (>90% certainty) the variant is pathogenic.',
-            'Benign': 'Very strong evidence the variant is benign',
-            'Likely Benign': 'Not expected to have a major effect on disease',
-            'Uncertain Significance': 'Does not fullfill the ACMG criteria for pathogenic/benign, or the evidence is conflicting',
-          },
-          'Functional': {
-            'Gain of Function': 'A sequence variant whereby new or enhanced function is conferred on the gene product',
-            'Loss of Function': 'A sequence variant whereby the gene product has diminished or abolished function',
-            'Unaltered Function': 'A sequence variant whereby the function of the gene product is unchanged',
-            'Neomorphic': 'TBD',
-            'Unknown': 'A functional variant that cannot be precisely defined by gain-of-function, loss-of-function, or unaltered function',
-          },
+          assertion: {
+            'Predictive': {
+              'Sensitivity/Response': 'Associated with a clinical or preclinical response to treatment',
+              'Resistance': 'Associated with clinical or preclinical resistance to treatment',
+              'Adverse Response': 'Associated with an adverse response to drug treatment',
+              'Reduced Sensitivity': 'Response to treatment is lower than seen in other treatment contexts',
+              'N/A': 'Variant does not inform clinical action'
+            },
+            'Diagnostic': {
+              'Positive': 'Associated with diagnosis of disease or subtype',
+              'Negative': 'Associated with lack of disease or subtype',
+            },
+            'Prognostic': {
+              'Better Outcome': 'Demonstrates better than expected clinical outcome',
+              'Poor Outcome': 'Demonstrates worse than expected clinical outcome',
+              'N/A': 'Variant does not inform clinical action'
+            },
+            'Predisposing': {
+              'Pathogenic': 'Very strong evidence the variant is pathogenic',
+              'Likely Pathogenic': 'Strong evidence (>90% certainty) the variant is pathogenic.',
+              'Benign': 'Very strong evidence the variant is benign',
+              'Likely Benign': 'Not expected to have a major effect on disease',
+              'Uncertain Significance': 'Does not fullfill the ACMG criteria for pathogenic/benign, or the evidence is conflicting',
+            },
+            'Functional': {
+              'Gain of Function': 'A sequence variant whereby new or enhanced function is conferred on the gene product',
+              'Loss of Function': 'A sequence variant whereby the gene product has diminished or abolished function',
+              'Unaltered Function': 'A sequence variant whereby the function of the gene product is unchanged',
+              'Neomorphic': 'TBD',
+              'Unknown': 'A functional variant that cannot be precisely defined by gain-of-function, loss-of-function, or unaltered function',
+            },
+          }
         },
         drug_interaction_type: {
           'Combination': 'The drugs listed were used in as part of a combination therapy approach',


### PR DESCRIPTION
Closes #1121. Will require server updates to handle accept N/A values for these fields.