### PR TITLE
Require conflict of interest statements from editors

### DIFF
--- a/src/app/views/account/profile/ProfileController.js
+++ b/src/app/views/account/profile/ProfileController.js
@@ -8,18 +8,14 @@
   function AccountProfileController($scope,
                                     Security,
                                     Users,
-                                    CurrentUser,
-                                    user,
-                                    statements){
+                                    CurrentUser){
     var vm = $scope.vm = {};
     vm.isAdmin = Security.isAdmin;
     vm.isEditor = Security.isEditor;
-    vm.user = user;
-    vm.statements = statements;
-    vm.userEdit = angular.copy(user);
+    vm.user = CurrentUser.data.user;
+    vm.statements = CurrentUser.data.statements;
+    vm.userEdit = angular.copy(vm.user);
     vm.userEdit.country_id = vm.userEdit.country === null ? null : vm.userEdit.country.id;
-    vm.currentUser = CurrentUser.data.user;
-    vm.coi = Security.currentUser.conflict_of_interest;
 
     vm.coiEdit = {
       coi_present: false,
@@ -32,6 +28,12 @@
 
     vm.submitCoiSuccess = false;
     vm.submitCoiFail = false;
+
+    $scope.$watch(function() {
+      return CurrentUser.data.user;
+    }, function(user) {
+      vm.user = user;
+    }, true);
 
     $scope.$watchCollection(function() {
       return CurrentUser.data.statements;
@@ -401,7 +403,7 @@
           label: null,
           options: [
             {value: false, name: 'I do not have any potential conflicts of interest'},
-            {value: true, name: 'I do have a potential conflict of interest'},
+            {value: true, name: 'I do have a potential conflict(s) of interest'},
           ],
           helpText: 'Please indicate if you have a conflict of interest in curating CIViC.'
         }

--- a/src/app/views/account/profile/ProfileController.js
+++ b/src/app/views/account/profile/ProfileController.js
@@ -12,12 +12,14 @@
                                     user,
                                     statements){
     var vm = $scope.vm = {};
-
+    vm.isAdmin = Security.isAdmin;
+    vm.isEditor = Security.isEditor;
     vm.user = user;
     vm.statements = statements;
     vm.userEdit = angular.copy(user);
     vm.userEdit.country_id = vm.userEdit.country === null ? null : vm.userEdit.country.id;
-    vm.currentUser = Security.currentUser;
+    vm.currentUser = CurrentUser.data.user;
+    vm.coi = Security.currentUser.conflict_of_interest;
 
     vm.coiEdit = {
       coi_present: false,
@@ -34,7 +36,7 @@
     $scope.$watchCollection(function() {
       return CurrentUser.data.statements;
     }, function(statements) {
-      vm.statements = statements;
+      vm.coi_statements = statements;
     });
 
     vm.userEditFields = [

--- a/src/app/views/account/profile/ProfileController.js
+++ b/src/app/views/account/profile/ProfileController.js
@@ -16,6 +16,11 @@
     vm.userEdit.country_id = vm.userEdit.country === null ? null : vm.userEdit.country.id;
     vm.currentUser = Security.currentUser;
 
+    vm.coiEdit = {
+      coi_present: false,
+      coi_statement: ''
+    };
+
     // TODO: implement better error handling and success message
     vm.submitSuccess = false;
     vm.submitFail = false;
@@ -370,7 +375,32 @@
           value: 'vm.userEdit.linkedin_profile',
           helpText: 'Your LinkedIn username, displayed on your profile page and user cards.'
         }
-      }
+      },
+    ];
+
+    vm.coiFields = [
+      {
+        template:'<h3 class="form-subheader">Conflict of Interest Statement <i class="badge" style="background-color: #F00;">OUT OF DATE</i></h3>'
+      },
+      {
+        key: 'bio',
+        type: 'horizontalTextareaHelp',
+        templateOptions: {
+          label: 'COI Statement',
+          rows: 4,
+          value: 'vm.userEdit.bio',
+          helpText: 'Provide a short statement that either clearly indicates that you do not have a conflict of interest in curating CIViC, or describe any conflicts of interest you may have.'
+        }
+      },
+      {
+        key: 'coi_present',
+        type: 'horizontalCheckboxHelp',
+        defaultValue: false,
+        templateOptions: {
+          label: 'I have a conflict of interest',
+          helpText: 'Check this box if your COI statement includes a conflict of interest.'
+        }
+      },
     ];
 
     vm.saveProfile = function(userEdit) {

--- a/src/app/views/account/profile/ProfileController.js
+++ b/src/app/views/account/profile/ProfileController.js
@@ -429,7 +429,7 @@
         .then(function() {
           console.log('updated user successfully');
           vm.submitSuccess = true;
-          vm.user = Security.reloadCurrentUser();
+          CurrentUser.get();
         })
         .catch(function() {
           console.error('update user error!');

--- a/src/app/views/account/profile/ProfileController.js
+++ b/src/app/views/account/profile/ProfileController.js
@@ -412,7 +412,10 @@
           rows: 4,
           helpText: 'Provide a concise description of any potential or actual conflicts of interest that you may have in curating CIViC.'
         },
-        hideExpression: '!model.coi_present'
+        hideExpression: '!model.coi_present',
+        expressionProperties: {
+          'templateOptions.required': 'model.coi_present === true'
+        }
       },
     ];
 
@@ -431,11 +434,12 @@
 
     };
 
-    vm.saveCoiStatement = function(coiEdit) {
+    vm.saveCoiStatement = function(coiEdit, coiOptions) {
       CurrentUser.addCoiStatement(coiEdit)
         .then(function() {
           console.log('added COI statement successfully.');
           vm.submitCoiSuccess = true;
+          coiOptions.resetModel();
         })
         .catch(function() {
           console.error('failed to add COI statement!');

--- a/src/app/views/account/profile/ProfileController.js
+++ b/src/app/views/account/profile/ProfileController.js
@@ -403,7 +403,7 @@
           label: null,
           options: [
             {value: false, name: 'I do not have any potential conflicts of interest'},
-            {value: true, name: 'I do have a potential conflict(s) of interest'},
+            {value: true, name: 'I do have a potential conflict of interest'},
           ],
           helpText: 'Please indicate if you have a conflict of interest in curating CIViC.'
         }

--- a/src/app/views/account/profile/ProfileView.js
+++ b/src/app/views/account/profile/ProfileView.js
@@ -17,6 +17,9 @@
           'CurrentUser': 'CurrentUser',
           'user': function (CurrentUser) {
             return CurrentUser.get();
+          },
+          'statements': function(CurrentUser) {
+            return CurrentUser.getCoiStatements();
           }
         },
         controller: 'AccountProfileController'

--- a/src/app/views/account/profile/profile.tpl.html
+++ b/src/app/views/account/profile/profile.tpl.html
@@ -44,6 +44,23 @@
         </div>
       </div>
       <form class="form-horizontal">
+        <h3 class="form-subheader">
+          Conflict of Interest Statement
+          <span ng-switch="vm.conflict_of_interest.coi_valid">
+            <span ng-switch-when="'expired'">
+              <i class="badge" style="background-color: #dc3545;">EXPIRED</i>
+            </span>
+            <span ng-switch-when="'missing'">
+              <i class="badge" style="background-color: #dc3545;">MISSING</i>
+            </span>
+            <span ng-switch-when="'conflict'">
+              <i class="badge" style="background-color: #ffc107;">CONFLICT</i>
+            </span>
+            <span ng-switch-when="'valid'">
+              <i class="badge" style="background-color: #28a745;">VALID</i>
+            </span>
+          </span>
+        </h3>
         <formly-form
           options="vm.coiOptions"
           model="vm.coiEdit"
@@ -57,7 +74,7 @@
             type="submit"
             class="btn btn-default"
             ng-disabled="vm.coiForm.$dirty === false"
-            ng-click="vm.saveCOI(vm.coiEdit, vm.coiOptions)">
+            ng-click="vm.saveCoiStatement(vm.coiEdit)">
             Save Conflict of Interest Statement
           </button>
         </div>
@@ -65,12 +82,12 @@
       <div class="row" style="margin-top: 1em;">
         <div class="col-xs-5 col-xs-offset-2">
           <div class="alert alert-success"
-            ng-show="vm.submitSuccess">
-            Profile updates successfully applied.
+            ng-show="vm.submitCoiSuccess">
+            Successfully updated your Conflict of Interest Statement.
           </div>
           <div class="alert alert-danger"
-            ng-show="vm.submitFail">
-            There was an error updating your profile! Please check the browser console for more information.
+            ng-show="vm.submitCoiFail">
+            There was an error updating your Conflict of Interest Statement! Please check the browser console for more information.
           </div>
         </div>
       </div>
@@ -80,10 +97,14 @@
 
 
   </div>
-  <!-- <div class="row"> -->
-  <!-- <div class="col-xs-6"> -->
-  <!-- <p>vm.userEdit:</p> -->
-  <!-- <pre ng-bind="vm.userEdit|json"></pre> -->
-  <!-- </div> -->
-  <!-- </div> -->
+  <div class="row">
+    <div class="col-xs-6">
+      <p>vm.coiEdit:</p>
+      <pre ng-bind="vm.coiEdit|json"></pre>
+    </div>
+    <div class="col-xs-6" >
+      <p>vm.statements</p>
+      <pre ng-bind="vm.statements|json"></pre>
+    </div>
+  </div>
 </div>

--- a/src/app/views/account/profile/profile.tpl.html
+++ b/src/app/views/account/profile/profile.tpl.html
@@ -148,18 +148,18 @@
 
 
   </div>
-  <div class="row">
-    <div class="col-xs-4">
-      <p>vm.user.conflict_of_interest:</p>
-      <pre ng-bind="vm.user.conflict_of_interest|json"></pre>
-    </div>
-    <div class="col-xs-4">
-      <p>vm.coiEdit:</p>
-      <pre ng-bind="vm.coiEdit|json"></pre>
-    </div>
-    <div class="col-xs-4" >
-      <p>vm.coi_statements</p>
-      <pre ng-bind="vm.coi_statements|json"></pre>
-    </div>
-  </div>
+  <!-- <div class="row"> -->
+  <!-- <div class="col-xs-4"> -->
+  <!-- <p>vm.user.conflict_of_interest:</p> -->
+  <!-- <pre ng-bind="vm.user.conflict_of_interest|json"></pre> -->
+  <!-- </div> -->
+  <!-- <div class="col-xs-4"> -->
+  <!-- <p>vm.coiEdit:</p> -->
+  <!-- <pre ng-bind="vm.coiEdit|json"></pre> -->
+  <!-- </div> -->
+  <!-- <div class="col-xs-4" > -->
+  <!-- <p>vm.coi_statements</p> -->
+  <!-- <pre ng-bind="vm.coi_statements|json"></pre> -->
+  <!-- </div> -->
+  <!-- </div> -->
 </div>

--- a/src/app/views/account/profile/profile.tpl.html
+++ b/src/app/views/account/profile/profile.tpl.html
@@ -48,7 +48,7 @@
           <h3 class="form-subheader">
             Conflict of Interest Statement
           </h3>
-          <div class="well" >
+          <div class="well" style="margin-bottom: 0; padding-bottom: 5px">
             <div class="form-group" >
               <label class="col-sm-2 control-label">
                 Status:
@@ -86,8 +86,12 @@
                     I do not have any potential conflicts of interest.
                   </span>
                   <span ng-switch-default="valid">
-                    I do have potential conflict(s) of interest:<br/>
-                    <p ng-bind="vm.user.conflict_of_interest.details.coi_statement"></p>
+                    I do have a potential conflict of interest:<br/>
+                    <p style="margin-bottom: 0">
+                      <i>
+                        {{vm.user.conflict_of_interest.details.coi_statement}}
+                      </i>
+                    </p>
                   </span>
                 </span>
               </div>

--- a/src/app/views/account/profile/profile.tpl.html
+++ b/src/app/views/account/profile/profile.tpl.html
@@ -38,12 +38,47 @@
             Profile updates successfully applied.
           </div>
           <div class="alert alert-danger"
-               ng-show="vm.submitFail">
+            ng-show="vm.submitFail">
             There was an error updating your profile! Please check the browser console for more information.
           </div>
         </div>
       </div>
+      <form class="form-horizontal">
+        <formly-form
+          options="vm.coiOptions"
+          model="vm.coiEdit"
+          form="vm.coiForm"
+          fields="vm.coiFields">
+        </formly-form>
+      </form>
+      <div class="row">
+        <div class="col-xs-10 col-xs-offset-2">
+          <button
+            type="submit"
+            class="btn btn-default"
+            ng-disabled="vm.coiForm.$dirty === false"
+            ng-click="vm.saveCOI(vm.coiEdit, vm.coiOptions)">
+            Save Conflict of Interest Statement
+          </button>
+        </div>
+      </div>
+      <div class="row" style="margin-top: 1em;">
+        <div class="col-xs-5 col-xs-offset-2">
+          <div class="alert alert-success"
+            ng-show="vm.submitSuccess">
+            Profile updates successfully applied.
+          </div>
+          <div class="alert alert-danger"
+            ng-show="vm.submitFail">
+            There was an error updating your profile! Please check the browser console for more information.
+          </div>
+        </div>
+      </div>
+
     </div>
+
+
+
   </div>
   <!-- <div class="row"> -->
   <!-- <div class="col-xs-6"> -->

--- a/src/app/views/account/profile/profile.tpl.html
+++ b/src/app/views/account/profile/profile.tpl.html
@@ -46,49 +46,51 @@
       <div ng-if="vm.isAdmin() || vm.isEditor()">
         <form class="form-horizontal">
           <h3 class="form-subheader">
-            Manage Conflict of Interest Statement
+            Conflict of Interest Statement
           </h3>
-          <div class="form-group" >
-            <label class="col-sm-2 control-label">
-              Status:
-            </label>
-            <div class="col-sm-2" style="padding-top: 6px;">
-              <span ng-switch="vm.user.conflict_of_interest.coi_valid">
-                <span ng-switch-when="expired">
-                  <i class="badge" style="background-color: #dc3545;">EXPIRED</i>
+          <div class="well" >
+            <div class="form-group" >
+              <label class="col-sm-2 control-label">
+                Status:
+              </label>
+              <div class="col-sm-2" style="padding-top: 6px;">
+                <span ng-switch="vm.user.conflict_of_interest.coi_valid">
+                  <span ng-switch-when="expired">
+                    <i class="badge" style="background-color: #dc3545;">EXPIRED</i>
+                  </span>
+                  <span ng-switch-when="missing">
+                    <i class="badge" style="background-color: #dc3545;">MISSING</i>
+                  </span>
+                  <span ng-switch-when="conflict">
+                    <i class="badge" style="background-color: #ffc107;">CONFLICT</i>
+                  </span>
+                  <span ng-switch-when="valid">
+                    <i class="badge" style="background-color: #28a745;">VALID</i>
+                  </span>
                 </span>
-                <span ng-switch-when="missing">
-                  <i class="badge" style="background-color: #dc3545;">MISSING</i>
-                </span>
-                <span ng-switch-when="conflict">
-                  <i class="badge" style="background-color: #ffc107;">CONFLICT</i>
-                </span>
-                <span ng-switch-when="valid">
-                  <i class="badge" style="background-color: #28a745;">VALID</i>
-                </span>
-              </span>
+              </div>
+              <div class="col-sm-4" ng-if="vm.user.conflict_of_interest.details.created_at" style="padding-top: 6px;">
+                <strong>Created:</strong> {{vm.user.conflict_of_interest.details.created_at | date: shortDate }}
+              </div>
+              <div class="col-sm-4" ng-if="vm.user.conflict_of_interest.details.expires_at" style="padding-top: 6px;">
+                <strong>Expires:</strong> {{vm.user.conflict_of_interest.details.expires_at | date: shortDate }}
+              </div>
             </div>
-            <div class="col-sm-4" ng-if="vm.user.conflict_of_interest.details.created_at" style="padding-top: 6px;">
-              <strong>Created:</strong> {{vm.user.conflict_of_interest.details.created_at | date: shortDate }}
-            </div>
-            <div class="col-sm-4" ng-if="vm.user.conflict_of_interest.details.expires_at" style="padding-top: 6px;">
-              <strong>Expires:</strong> {{vm.user.conflict_of_interest.details.expires_at | date: shortDate }}
-            </div>
-          </div>
-          <div class="form-group" ng-if="vm.user.conflict_of_interest.coi_valid !== 'missing'">
-            <label class="col-sm-2 control-label">
-              Statement:
-            </label>
-            <div class="col-sm-10" style="padding-top: 6px;">
-              <span ng-switch="vm.user.conflict_of_interest.coi_valid">
-                <span ng-switch-when="valid">
-                  I do not have any potential conflicts of interest.
+            <div class="form-group" ng-if="vm.user.conflict_of_interest.coi_valid !== 'missing'">
+              <label class="col-sm-2 control-label">
+                Statement:
+              </label>
+              <div class="col-sm-10" style="padding-top: 6px;">
+                <span ng-switch="vm.user.conflict_of_interest.coi_valid">
+                  <span ng-switch-when="valid">
+                    I do not have any potential conflicts of interest.
+                  </span>
+                  <span ng-switch-default="valid">
+                    I do have potential conflict(s) of interest:<br/>
+                    <p ng-bind="vm.user.conflict_of_interest.details.coi_statement"></p>
+                  </span>
                 </span>
-                <span ng-switch-default="valid">
-                  I do have potential conflict(s) of interest:<br/>
-                  <p ng-bind="vm.user.conflict_of_interest.details.coi_statement"></p>
-                </span>
-              </span>
+              </div>
             </div>
           </div>
           <div class="form-group">
@@ -96,13 +98,13 @@
               <h4 style="margin-bottom:0;">
                 <span ng-switch="vm.user.conflict_of_interest.coi_valid">
                   <span ng-switch-when="missing" >
-                    Add
+                    Add a
                   </span>
                   <span ng-switch-default>
-                    Update
+                    Update Your
                   </span>
                 </span>
-                 Your Conflict of Interest Statement:
+                Conflict of Interest Statement:
               </h4>
             </div>
           </div>

--- a/src/app/views/account/profile/profile.tpl.html
+++ b/src/app/views/account/profile/profile.tpl.html
@@ -73,8 +73,8 @@
           <button
             type="submit"
             class="btn btn-default"
-            ng-disabled="vm.coiForm.$dirty === false"
-            ng-click="vm.saveCoiStatement(vm.coiEdit)">
+            ng-disabled="vm.coiForm.$invalid"
+            ng-click="vm.saveCoiStatement(vm.coiEdit, vm.coiOptions)">
             Save Conflict of Interest Statement
           </button>
         </div>

--- a/src/app/views/account/profile/profile.tpl.html
+++ b/src/app/views/account/profile/profile.tpl.html
@@ -34,7 +34,7 @@
       <div class="row" style="margin-top: 1em;">
         <div class="col-xs-5 col-xs-offset-2">
           <div class="alert alert-success"
-          ng-show="vm.submitSuccess">
+            ng-show="vm.submitSuccess">
             Profile updates successfully applied.
           </div>
           <div class="alert alert-danger"
@@ -43,68 +43,95 @@
           </div>
         </div>
       </div>
-      <form class="form-horizontal">
-        <h3 class="form-subheader">
-          Conflict of Interest Statement
-          <span ng-switch="vm.conflict_of_interest.coi_valid">
-            <span ng-switch-when="'expired'">
-              <i class="badge" style="background-color: #dc3545;">EXPIRED</i>
-            </span>
-            <span ng-switch-when="'missing'">
-              <i class="badge" style="background-color: #dc3545;">MISSING</i>
-            </span>
-            <span ng-switch-when="'conflict'">
-              <i class="badge" style="background-color: #ffc107;">CONFLICT</i>
-            </span>
-            <span ng-switch-when="'valid'">
-              <i class="badge" style="background-color: #28a745;">VALID</i>
-            </span>
-          </span>
-        </h3>
-        <formly-form
-          options="vm.coiOptions"
-          model="vm.coiEdit"
-          form="vm.coiForm"
-          fields="vm.coiFields">
-        </formly-form>
-      </form>
-      <div class="row">
-        <div class="col-xs-10 col-xs-offset-2">
-          <button
-            type="submit"
-            class="btn btn-default"
-            ng-disabled="vm.coiForm.$invalid"
-            ng-click="vm.saveCoiStatement(vm.coiEdit, vm.coiOptions)">
-            Save Conflict of Interest Statement
-          </button>
+      <div ng-if="vm.isAdmin() || vm.isEditor()">
+        <form class="form-horizontal">
+          <h3 class="form-subheader">
+            Manage Conflict of Interest Statement
+          </h3>
+          <div class="form-group" >
+            <label class="col-sm-2 control-label">
+              Status:
+            </label>
+            <div class="col-sm-10" style="padding-top: 6px;">
+              <span ng-switch="vm.currentUser.conflict_of_interest.coi_valid">
+                <span ng-switch-when="expired">
+                  <i class="badge" style="background-color: #dc3545;">EXPIRED</i>
+                </span>
+                <span ng-switch-when="missing">
+                  <i class="badge" style="background-color: #dc3545;">MISSING</i>
+                </span>
+                <span ng-switch-when="conflict">
+                  <i class="badge" style="background-color: #ffc107;">CONFLICT</i>
+                </span>
+                <span ng-switch-when="valid">
+                  <i class="badge" style="background-color: #28a745;">VALID</i>
+                </span>
+              </span>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-10 col-sm-offset-2">
+              <h4 style="margin-bottom:0;">
+                <span ng-switch="vm.currentUser.conflict_of_interest.coi_valid">
+                  <span ng-switch-when="missing" >
+                    Add
+                  </span>
+                  <span ng-switch-default>
+                    Update
+                  </span>
+                </span>
+                 Your Conflict of Interest Statement:
+              </h4>
+            </div>
+          </div>
+          <formly-form
+            options="vm.coiOptions"
+            model="vm.coiEdit"
+            form="vm.coiForm"
+            fields="vm.coiFields">
+          </formly-form>
+        </form>
+        <div class="row">
+          <div class="col-xs-10 col-xs-offset-2">
+            <button
+              type="submit"
+              class="btn btn-default"
+              ng-disabled="vm.coiForm.$invalid"
+              ng-click="vm.saveCoiStatement(vm.coiEdit, vm.coiOptions)">
+              Save Conflict of Interest Statement
+            </button>
+          </div>
+        </div>
+        <div class="row" style="margin-top: 1em;">
+          <div class="col-xs-5 col-xs-offset-2">
+            <div class="alert alert-success"
+              ng-show="vm.submitCoiSuccess">
+              Successfully updated your Conflict of Interest Statement.
+            </div>
+            <div class="alert alert-danger"
+              ng-show="vm.submitCoiFail">
+              There was an error updating your Conflict of Interest Statement! Please check the browser console for more information.
+            </div>
+          </div>
         </div>
       </div>
-      <div class="row" style="margin-top: 1em;">
-        <div class="col-xs-5 col-xs-offset-2">
-          <div class="alert alert-success"
-            ng-show="vm.submitCoiSuccess">
-            Successfully updated your Conflict of Interest Statement.
-          </div>
-          <div class="alert alert-danger"
-            ng-show="vm.submitCoiFail">
-            There was an error updating your Conflict of Interest Statement! Please check the browser console for more information.
-          </div>
-        </div>
-      </div>
-
     </div>
 
 
 
   </div>
   <div class="row">
-    <div class="col-xs-6">
+    <div class="col-xs-4">
+      <p>vm.coi:</p>
+      <pre ng-bind="vm.coi|json"></pre>
+    </div>
+    <div class="col-xs-4">
       <p>vm.coiEdit:</p>
       <pre ng-bind="vm.coiEdit|json"></pre>
     </div>
-    <div class="col-xs-6" >
-      <p>vm.statements</p>
-      <pre ng-bind="vm.statements|json"></pre>
+    <div class="col-xs-4" >
+      <p>vm.coi_statements</p>
+      <pre ng-bind="vm.coi_statements|json"></pre>
     </div>
   </div>
 </div>

--- a/src/app/views/account/profile/profile.tpl.html
+++ b/src/app/views/account/profile/profile.tpl.html
@@ -52,8 +52,8 @@
             <label class="col-sm-2 control-label">
               Status:
             </label>
-            <div class="col-sm-10" style="padding-top: 6px;">
-              <span ng-switch="vm.currentUser.conflict_of_interest.coi_valid">
+            <div class="col-sm-2" style="padding-top: 6px;">
+              <span ng-switch="vm.user.conflict_of_interest.coi_valid">
                 <span ng-switch-when="expired">
                   <i class="badge" style="background-color: #dc3545;">EXPIRED</i>
                 </span>
@@ -68,11 +68,33 @@
                 </span>
               </span>
             </div>
+            <div class="col-sm-4" ng-if="vm.user.conflict_of_interest.details.created_at" style="padding-top: 6px;">
+              <strong>Created:</strong> {{vm.user.conflict_of_interest.details.created_at | date: shortDate }}
+            </div>
+            <div class="col-sm-4" ng-if="vm.user.conflict_of_interest.details.expires_at" style="padding-top: 6px;">
+              <strong>Expires:</strong> {{vm.user.conflict_of_interest.details.expires_at | date: shortDate }}
+            </div>
+          </div>
+          <div class="form-group" ng-if="vm.user.conflict_of_interest.coi_valid !== 'missing'">
+            <label class="col-sm-2 control-label">
+              Statement:
+            </label>
+            <div class="col-sm-10" style="padding-top: 6px;">
+              <span ng-switch="vm.user.conflict_of_interest.coi_valid">
+                <span ng-switch-when="valid">
+                  I do not have any potential conflicts of interest.
+                </span>
+                <span ng-switch-default="valid">
+                  I do have potential conflict(s) of interest:<br/>
+                  <p ng-bind="vm.user.conflict_of_interest.details.coi_statement"></p>
+                </span>
+              </span>
+            </div>
           </div>
           <div class="form-group">
             <div class="col-sm-10 col-sm-offset-2">
               <h4 style="margin-bottom:0;">
-                <span ng-switch="vm.currentUser.conflict_of_interest.coi_valid">
+                <span ng-switch="vm.user.conflict_of_interest.coi_valid">
                   <span ng-switch-when="missing" >
                     Add
                   </span>
@@ -122,8 +144,8 @@
   </div>
   <div class="row">
     <div class="col-xs-4">
-      <p>vm.coi:</p>
-      <pre ng-bind="vm.coi|json"></pre>
+      <p>vm.user.conflict_of_interest:</p>
+      <pre ng-bind="vm.user.conflict_of_interest|json"></pre>
     </div>
     <div class="col-xs-4">
       <p>vm.coiEdit:</p>

--- a/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
+++ b/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
@@ -211,7 +211,7 @@
     <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
       <a ui-sref="account.profile" class="btn btn-danger btn-block">
         <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
-        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+        Your Editor's Conflict of Interest Statement is missing or expired. Please update it to perform moderation.
       </a>
     </div>
   </div>

--- a/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
+++ b/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
@@ -181,7 +181,7 @@
       </div>
     </div>
   </div>
-  <div class="row" ng-if="(vm.isEditor || vm.isAdmin || (vm.isCurator && vm.ownerIsCurrentUser)) && vm.assertion.status === 'submitted'" style="margin-top: 1em; margin-bottom: 1em;">
+  <div class="row" ng-if="vm.showModeration" style="margin-top: 1em; margin-bottom: 1em;">
     <div class="col-xs-6">
       <a class="btn btn-default btn-block btn-danger" ng-click="rejectItem(vm.assertion.id)">
         Reject Assertion
@@ -205,6 +205,14 @@
           </a>
         </span>
       </span>
+    </div>
+  </div>
+  <div class="row" ng-if="vm.showCoiNotice">
+    <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
+      <a ui-sref="account.profile" class="btn btn-danger btn-block">
+        <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
+        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+      </a>
     </div>
   </div>
   <div class="row">

--- a/src/app/views/events/assertions/talk/revisions/assertionTalkRevisionSummary.js
+++ b/src/app/views/events/assertions/talk/revisions/assertionTalkRevisionSummary.js
@@ -29,13 +29,24 @@
     vm.errorMessages = formConfig.errorMessages;
     vm.errorPrompts = formConfig.errorPrompts;
 
-    if(Security.currentUser) {
-      var currentUserId = Security.currentUser.id;
-      var submitterId = AssertionRevisions.data.item.user.id;
-      vm.ownerIsCurrentUser = submitterId === currentUserId;
-    } else {
-      vm.ownerIsCurrentUser = false;
-    }
+    // determine moderation button visibility
+    var currentUserId = Security.currentUser.id;
+    var submitterId = AssertionRevisions.data.item.user.id;
+    var ownerIsCurrentUser = vm.ownerIsCurrentUser = submitterId === currentUserId;
+
+    $scope.$watchGroup(
+      [ function() { return AssertionRevisions.data.item.status; },
+        function() { return Security.currentUser.conflict_of_interest.coi_valid; } ],
+      function(statuses) {
+        var changeStatus = statuses[0];
+        var coiStatus = statuses[1];
+        var changeIsNew = changeStatus === 'new';
+        var coiValid = coiStatus === 'conflict' || coiStatus === 'valid';
+        var isModerator = Security.isEditor() || Security.isAdmin();
+
+        vm.showModeration = changeIsNew && ((isModerator && coiValid) || ownerIsCurrentUser);
+        vm.showCoiNotice = changeIsNew && !vm.showModeration && isModerator;
+      });
 
     vm.disabled_text = (vm.isEditor() || vm.isAdmin()) ? 'Contributors may not accept their own suggested revisions.' : 'Suggested revisions must be approved by an editor.' ;
 

--- a/src/app/views/events/assertions/talk/revisions/assertionTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/assertions/talk/revisions/assertionTalkRevisionSummary.tpl.html
@@ -92,21 +92,30 @@
       </ul>
     </div>
   </div>
-  <div class="row">
-    <div class="col-xs-12 admin-buttons" ng-if="(vm.isEditor() || vm.isAdmin() || vm.ownerIsCurrentUser) && vm.assertionTalkModel.data.item.status === 'new'">
+  <div class="row" ng-if="vm.showModeration">
+    <div class="col-xs-12 admin-buttons">
       <div class="pull-right">
         <span uib-tooltip={{vm.disabled_text}}
               tooltip-append-to-body="true"
               tooltip-enable="vm.ownerIsCurrentUser">
-          <a class="btn btn-default"
-            ng-disabled="vm.ownerIsCurrentUser"
-            ng-click="acceptRevision()">
+          <button type="submit"
+                  class="btn btn-default"
+                  ng-disabled="vm.ownerIsCurrentUser"
+                  ng-click="acceptRevision()">
             Accept Revision
-          </a>
+          </button>
         </span>
 
-        <a class="btn btn-default" ng-click="rejectRevision()">Reject Revision</a>
+        <button type="submit" class="btn btn-default" ng-click="rejectRevision()">Reject Revision</button>
       </div>
+    </div>
+  </div>
+  <div class="row" ng-if="vm.showCoiNotice">
+    <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
+      <a ui-sref="account.profile" class="btn btn-danger btn-block">
+        <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
+        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+      </a>
     </div>
   </div>
   <div class="row">

--- a/src/app/views/events/assertions/talk/revisions/assertionTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/assertions/talk/revisions/assertionTalkRevisionSummary.tpl.html
@@ -114,7 +114,7 @@
     <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
       <a ui-sref="account.profile" class="btn btn-danger btn-block">
         <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
-        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+        Your Editor's Conflict of Interest Statement is missing or expired. Please update it to perform moderation.
       </a>
     </div>
   </div>

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -189,7 +189,7 @@
     <div class="col-xs-10 col-xs-offset-1">
       <a ui-sref="account.profile" class="btn btn-danger btn-block">
         <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
-        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+        Your Editor's Conflict of Interest Statement is missing or expired. Please update it to perform moderation.
       </a>
     </div>
   </div>

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -165,7 +165,7 @@
       </table>
     </div>
   </div>
-  <div class="row" ng-if="(isEditor() || isAdmin() || (isCurator() && ownerIsCurrentUser)) && evidence.status === 'submitted'" style="margin-top: 1em;">
+  <div class="row" ng-if="showModeration" style="margin-top: 1em;">
     <div class="col-xs-6">
       <a class="btn btn-default btn-block btn-danger"
         ng-click="rejectItem(evidence.id)">
@@ -183,6 +183,14 @@
           Accept Evidence Item
         </a>
       </span>
+    </div>
+  </div>
+  <div class="row" ng-if="showCoiNotice">
+    <div class="col-xs-10 col-xs-offset-1">
+      <a ui-sref="account.profile" class="btn btn-danger btn-block">
+        <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
+        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+      </a>
     </div>
   </div>
   <!--<div class="row">-->

--- a/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.js
+++ b/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.js
@@ -33,13 +33,24 @@
     vm.errorMessages = formConfig.errorMessages;
     vm.errorPrompts = formConfig.errorPrompts;
 
-    if(Security.currentUser) {
-      var currentUserId = Security.currentUser.id;
-      var submitterId = EvidenceRevisions.data.item.user.id;
-      vm.ownerIsCurrentUser = submitterId === currentUserId;
-    } else {
-      vm.ownerIsCurrentUser = false;
-    }
+    // determine moderation button visibility
+    var currentUserId = Security.currentUser.id;
+    var submitterId = EvidenceRevisions.data.item.user.id;
+    var ownerIsCurrentUser = vm.ownerIsCurrentUser = submitterId === currentUserId;
+
+    $scope.$watchGroup(
+      [ function() { return EvidenceRevisions.data.item.status; },
+        function() { return Security.currentUser.conflict_of_interest.coi_valid; } ],
+      function(statuses) {
+        var changeStatus = statuses[0];
+        var coiStatus = statuses[1];
+        var changeIsNew = changeStatus === 'new';
+        var coiValid = coiStatus === 'conflict' || coiStatus === 'valid';
+        var isModerator = Security.isEditor() || Security.isAdmin();
+
+        vm.showModeration = changeIsNew && ((isModerator && coiValid) || ownerIsCurrentUser);
+        vm.showCoiNotice = changeIsNew && !vm.showModeration && isModerator;
+      });
 
     vm.disabled_text = (vm.isEditor() || vm.isAdmin()) ? 'Contributors may not accept their own suggested revisions.' : 'Suggested revisions must be approved by an editor.' ;
 

--- a/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.tpl.html
@@ -118,7 +118,7 @@
     <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
       <a ui-sref="account.profile" class="btn btn-danger btn-block">
         <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
-        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+        Your Editor's Conflict of Interest Statement is missing or expired. Please update it to perform moderation.
       </a>
     </div>
   </div>

--- a/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.tpl.html
@@ -96,8 +96,8 @@
       </ul>
     </div>
   </div>
-  <div class="row">
-    <div class="col-xs-12 admin-buttons" ng-if="(vm.isEditor() || vm.isAdmin() || vm.ownerIsCurrentUser) && vm.evidenceTalkModel.data.item.status ==='new'">
+  <div class="row" ng-if="vm.showModeration">
+    <div class="col-xs-12 admin-buttons">
       <div class="pull-right">
         <span uib-tooltip={{vm.disabled_text}}
               tooltip-append-to-body="true"
@@ -110,10 +110,16 @@
           </button>
         </span>
 
-        <button type="submit" class="btn btn-default" ng-click="rejectRevision()">
-          Reject Revision
-        </button>
+        <button type="submit" class="btn btn-default" ng-click="rejectRevision()">Reject Revision</button>
       </div>
+    </div>
+  </div>
+  <div class="row" ng-if="vm.showCoiNotice">
+    <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
+      <a ui-sref="account.profile" class="btn btn-danger btn-block">
+        <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
+        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+      </a>
     </div>
   </div>
   <div class="row">

--- a/src/app/views/events/genes/talk/revisions/geneTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/genes/talk/revisions/geneTalkRevisionSummary.tpl.html
@@ -91,7 +91,7 @@
     <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
       <a ui-sref="account.profile" class="btn btn-danger btn-block">
         <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
-        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+        Your Editor's Conflict of Interest Statement is missing or expired. Please update it to perform moderation.
       </a>
     </div>
   </div>

--- a/src/app/views/events/genes/talk/revisions/geneTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/genes/talk/revisions/geneTalkRevisionSummary.tpl.html
@@ -69,8 +69,8 @@
       </ul>
     </div>
   </div>
-  <div class="row">
-    <div class="col-xs-12 admin-buttons" ng-if="(vm.isEditor() || vm.isAdmin() || vm.ownerIsCurrentUser) && vm.geneTalkModel.data.item.status === 'new'">
+  <div class="row" ng-if="vm.showModeration">
+    <div class="col-xs-12 admin-buttons">
       <div class="pull-right">
         <span uib-tooltip={{vm.disabled_text}}
               tooltip-append-to-body="true"
@@ -85,6 +85,14 @@
 
         <button type="submit" class="btn btn-default" ng-click="rejectRevision()">Reject Revision</button>
       </div>
+    </div>
+  </div>
+  <div class="row" ng-if="vm.showCoiNotice">
+    <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
+      <a ui-sref="account.profile" class="btn btn-danger btn-block">
+        <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
+        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+      </a>
     </div>
   </div>
   <div class="row">

--- a/src/app/views/events/variantGroups/talk/revisions/variantGroupTalkRevisionSummary.js
+++ b/src/app/views/events/variantGroups/talk/revisions/variantGroupTalkRevisionSummary.js
@@ -28,13 +28,26 @@
     vm.errorMessages = formConfig.errorMessages;
     vm.errorPrompts = formConfig.errorPrompts;
 
-    if(Security.currentUser) {
-      var currentUserId = Security.currentUser.id;
-      var submitterId = VariantGroupRevisions.data.item.user.id;
-      vm.ownerIsCurrentUser = submitterId === currentUserId;
-    } else {
-      vm.ownerIsCurrentUser = false;
-    }
+    // determine moderation button visibility
+    var currentUserId = Security.currentUser.id;
+    var submitterId = VariantGroupRevisions.data.item.user.id;
+    var ownerIsCurrentUser = vm.ownerIsCurrentUser = submitterId === currentUserId;
+
+    $scope.$watchGroup(
+      [ function() { return VariantGroupRevisions.data.item.status; },
+        function() { return Security.currentUser.conflict_of_interest.coi_valid; } ],
+      function(statuses) {
+        var changeStatus = statuses[0];
+        var coiStatus = statuses[1];
+        var changeIsNew = changeStatus === 'new';
+        var coiValid = coiStatus === 'conflict' || coiStatus === 'valid';
+        var isModerator = Security.isEditor() || Security.isAdmin();
+
+        vm.showModeration = changeIsNew && ((isModerator && coiValid) || ownerIsCurrentUser);
+        vm.showCoiNotice = changeIsNew && !vm.showModeration && isModerator;
+      });
+
+    vm.disabled_text = (vm.isEditor() || vm.isAdmin()) ? 'Contributors may not accept their own suggested revisions.' : 'Suggested revisions must be approved by an editor.' ;
 
     vm.disabled_text = (vm.isEditor() || vm.isAdmin()) ? 'Contributors may not accept their own suggested revisions.' : 'Suggested revisions must be approved by an editor.' ;
 

--- a/src/app/views/events/variantGroups/talk/revisions/variantGroupTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/variantGroups/talk/revisions/variantGroupTalkRevisionSummary.tpl.html
@@ -91,7 +91,7 @@
     <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
       <a ui-sref="account.profile" class="btn btn-danger btn-block">
         <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
-        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+        Your Editor's Conflict of Interest Statement is missing or expired. Please update it to perform moderation.
       </a>
     </div>
   </div>

--- a/src/app/views/events/variantGroups/talk/revisions/variantGroupTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/variantGroups/talk/revisions/variantGroupTalkRevisionSummary.tpl.html
@@ -69,8 +69,8 @@
       </ul>
     </div>
   </div>
-  <div class="row">
-    <div class="col-xs-12 admin-buttons" ng-if="(vm.isEditor() || vm.isAdmin() || vm.ownerIsCurrentUser) && vm.variantGroupTalkModel.data.item.status === 'new'">
+  <div class="row" ng-if="vm.showModeration">
+    <div class="col-xs-12 admin-buttons">
       <div class="pull-right">
         <span uib-tooltip={{vm.disabled_text}}
               tooltip-append-to-body="true"
@@ -81,9 +81,18 @@
                   ng-click="acceptRevision()">
             Accept Revision
           </button>
-          </span>
+        </span>
+
         <button type="submit" class="btn btn-default" ng-click="rejectRevision()">Reject Revision</button>
       </div>
+    </div>
+  </div>
+  <div class="row" ng-if="vm.showCoiNotice">
+    <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
+      <a ui-sref="account.profile" class="btn btn-danger btn-block">
+        <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
+        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+      </a>
     </div>
   </div>
   <div class="row">

--- a/src/app/views/events/variants/talk/revisions/variantTalkRevisionSummary.js
+++ b/src/app/views/events/variants/talk/revisions/variantTalkRevisionSummary.js
@@ -33,13 +33,24 @@
     vm.errorMessages = formConfig.errorMessages;
     vm.errorPrompts = formConfig.errorPrompts;
 
-    if(Security.currentUser) {
-      var currentUserId = Security.currentUser.id;
-      var submitterId = VariantRevisions.data.item.user.id;
-      vm.ownerIsCurrentUser = submitterId === currentUserId;
-    } else {
-      vm.ownerIsCurrentUser = false;
-    }
+    // determine moderation button visibility
+    var currentUserId = Security.currentUser.id;
+    var submitterId = VariantRevisions.data.item.user.id;
+    var ownerIsCurrentUser = vm.ownerIsCurrentUser = submitterId === currentUserId;
+
+    $scope.$watchGroup(
+      [ function() { return VariantRevisions.data.item.status; },
+        function() { return Security.currentUser.conflict_of_interest.coi_valid; } ],
+      function(statuses) {
+        var changeStatus = statuses[0];
+        var coiStatus = statuses[1];
+        var changeIsNew = changeStatus === 'new';
+        var coiValid = coiStatus === 'conflict' || coiStatus === 'valid';
+        var isModerator = Security.isEditor() || Security.isAdmin();
+
+        vm.showModeration = changeIsNew && ((isModerator && coiValid) || ownerIsCurrentUser);
+        vm.showCoiNotice = changeIsNew && !vm.showModeration && isModerator;
+      });
 
     vm.disabled_text = (vm.isEditor() || vm.isAdmin()) ? 'Contributors may not accept their own suggested revisions.' : 'Suggested revisions must be approved by an editor.';
 

--- a/src/app/views/events/variants/talk/revisions/variantTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/variants/talk/revisions/variantTalkRevisionSummary.tpl.html
@@ -91,7 +91,7 @@
     <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
       <a ui-sref="account.profile" class="btn btn-danger btn-block">
         <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
-        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+        Your Editor's Conflict of Interest Statement is missing or expired. Please update it to perform moderation.
       </a>
     </div>
   </div>

--- a/src/app/views/events/variants/talk/revisions/variantTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/variants/talk/revisions/variantTalkRevisionSummary.tpl.html
@@ -69,8 +69,8 @@
       </ul>
     </div>
   </div>
-  <div class="row">
-    <div class="col-xs-12 admin-buttons" ng-if="(vm.isEditor() || vm.isAdmin() || vm.ownerIsCurrentUser) && vm.variantTalkModel.data.item.status === 'new'">
+  <div class="row" ng-if="vm.showModeration">
+    <div class="col-xs-12 admin-buttons">
       <div class="pull-right">
         <span uib-tooltip={{vm.disabled_text}}
               tooltip-append-to-body="true"
@@ -82,8 +82,17 @@
             Accept Revision
           </button>
         </span>
+
         <button type="submit" class="btn btn-default" ng-click="rejectRevision()">Reject Revision</button>
       </div>
+    </div>
+  </div>
+  <div class="row" ng-if="vm.showCoiNotice">
+    <div class="col-xs-10 col-xs-offset-1" style="padding-bottom: 16px">
+      <a ui-sref="account.profile" class="btn btn-danger btn-block">
+        <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
+        Your Editor's Conflict of Information Statement is missing or expired. Please update it now perform moderation.
+      </a>
     </div>
   </div>
   <div class="row">

--- a/src/app/views/users/common/userSummary.tpl.html
+++ b/src/app/views/users/common/userSummary.tpl.html
@@ -109,9 +109,14 @@
           </div>
         </div>
       </div>
+      <div class="row" >
+        <div class="col-xs-12">
+          <h5 style="color: #CCC; margin-top: 0px;">Editor's Conflict of Interest Statement</h5>
+        </div>
+      </div>
       <div class="row">
         <div class="col-xs-12">
-          <div class="well" style="margin-bottom: 0; padding-bottom: 5px">
+          <div class="well" style="margin-bottom: 0; padding-bottom: 12px">
             <div class="row">
               <div class="col-sm-2" style="text-align: right;">
                 <strong>Status:</strong>
@@ -139,7 +144,7 @@
                 <strong>Expires:</strong> {{user.conflict_of_interest.details.expires_at | date: shortDate }}
               </div>
             </div>
-            <div class="row" ng-if="user.conflict_of_interest.coi_valid !== 'missing'">
+            <div class="row" ng-if="user.conflict_of_interest.coi_valid !== 'missing'" style="padding-top: 8px;">
               <div class="col-sm-2" style="text-align: right;">
                 <strong>Statement:</strong>
               </div>

--- a/src/app/views/users/common/userSummary.tpl.html
+++ b/src/app/views/users/common/userSummary.tpl.html
@@ -109,6 +109,26 @@
           </div>
         </div>
       </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <div class="info-block">
+            <table class="table-info" >
+              <tr>
+                <td colspan="2">
+                  <p><span class="key">Editor Conflict of Interest Statement:</span><br/>
+                    <span class="value" >
+                      Pellentesque dapibus suscipit ligula. Donec posuere augue in quam. Etiam vel tortor sodales tellus ultricies commodo. Suspendisse potenti.
+                    </span>
+                  </p>
+                </td>
+              </tr>
+              <tr>
+                <td><i>The Editor has indicated that this statement does not include any conflicts of interest.</i></td>
+              </tr>
+            </table>
+          </div>
+        </div>
+      </div>
       <div class="row" ng-if="user.trophy_case.badges.length > 0">
         <div class="col-xs-12">
           <h5 class="sub-title">Badges:</h5>

--- a/src/app/views/users/common/userSummary.tpl.html
+++ b/src/app/views/users/common/userSummary.tpl.html
@@ -111,34 +111,68 @@
       </div>
       <div class="row">
         <div class="col-xs-12">
-          <div class="info-block">
-            <table class="table-info" >
-              <tr>
-                <td colspan="2">
-                  <p><span class="key">Editor Conflict of Interest Statement:</span><br/>
-                    <span class="value" >
-                      Pellentesque dapibus suscipit ligula. Donec posuere augue in quam. Etiam vel tortor sodales tellus ultricies commodo. Suspendisse potenti.
-                    </span>
-                  </p>
-                </td>
-              </tr>
-              <tr>
-                <td><i>The Editor has indicated that this statement does not include any conflicts of interest.</i></td>
-              </tr>
-            </table>
-          </div>
-        </div>
-      </div>
-      <div class="row" ng-if="user.trophy_case.badges.length > 0">
-        <div class="col-xs-12">
-          <h5 class="sub-title">Badges:</h5>
-          <div class="info-block" style="padding-bottom: 10px;">
-            <span ng-repeat="badge in user.trophy_case.badges">
-              <trophy-badge badge="badge"></trophy-badge>
-            </span>
+          <div class="well" style="margin-bottom: 0; padding-bottom: 5px">
+            <div class="row">
+              <div class="col-sm-2" style="text-align: right;">
+                <strong>Status:</strong>
+              </div>
+              <div class="col-sm-2">
+                <span ng-switch="user.conflict_of_interest.coi_valid">
+                  <span ng-switch-when="expired">
+                    <i class="badge" style="background-color: #dc3545;">EXPIRED</i>
+                  </span>
+                  <span ng-switch-when="missing">
+                    <i class="badge" style="background-color: #dc3545;">MISSING</i>
+                  </span>
+                  <span ng-switch-when="conflict">
+                    <i class="badge" style="background-color: #ffc107;">CONFLICT</i>
+                  </span>
+                  <span ng-switch-when="valid">
+                    <i class="badge" style="background-color: #28a745;">VALID</i>
+                  </span>
+                </span>
+              </div>
+              <div class="col-sm-4" ng-if="user.conflict_of_interest.details.created_at">
+                <strong>Created:</strong> {{user.conflict_of_interest.details.created_at | date: shortDate }}
+              </div>
+              <div class="col-sm-4" ng-if="user.conflict_of_interest.details.expires_at">
+                <strong>Expires:</strong> {{user.conflict_of_interest.details.expires_at | date: shortDate }}
+              </div>
+            </div>
+            <div class="row" ng-if="user.conflict_of_interest.coi_valid !== 'missing'">
+              <div class="col-sm-2" style="text-align: right;">
+                <strong>Statement:</strong>
+              </div>
+              <div class="col-sm-10">
+                <span ng-switch="user.conflict_of_interest.coi_valid">
+                  <span ng-switch-when="valid">
+                    I do not have any potential conflicts of interest.
+                  </span>
+                  <span ng-switch-default="valid">
+                    I do have a potential conflict of interest:<br/>
+                    <p style="margin-bottom: 0">
+                      <i>
+                        {{user.conflict_of_interest.details.coi_statement}}
+                      </i>
+                    </p>
+                  </span>
+                </span>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
+    <div class="row" ng-if="user.trophy_case.badges.length > 0">
+      <div class="col-xs-12">
+        <h5 class="sub-title">Badges:</h5>
+        <div class="info-block" style="padding-bottom: 10px;">
+          <span ng-repeat="badge in user.trophy_case.badges">
+            <trophy-badge badge="badge"></trophy-badge>
+          </span>
+        </div>
+      </div>
+    </div>
   </div>
+</div>
 </div>

--- a/src/components/directives/loginButton.js
+++ b/src/components/directives/loginButton.js
@@ -23,6 +23,7 @@
         $scope.logout = Security.logout;
         $scope.showLogin = Security.showLogin;
 
+
         $scope.$watch(function() {
           return Security.currentUser;
         }, function(currentUser) {
@@ -32,6 +33,9 @@
               return acc + value;
             });
             $scope.hasNotifications = $scope.totalNotifications > 0;
+
+            $scope.showCoiNotice = (Security.isAdmin() || Security.isEditor())
+              && currentUser.conflict_of_interest.coi_valid !== 'valid';
           }
         });
 

--- a/src/components/directives/loginButton.js
+++ b/src/components/directives/loginButton.js
@@ -35,7 +35,8 @@
             $scope.hasNotifications = $scope.totalNotifications > 0;
 
             $scope.showCoiNotice = (Security.isAdmin() || Security.isEditor())
-              && currentUser.conflict_of_interest.coi_valid !== 'valid';
+              && (currentUser.conflict_of_interest.coi_valid === 'missing' ||
+                  currentUser.conflict_of_interest.coi_valid === 'expired' );
           }
         });
 

--- a/src/components/directives/loginButton.less
+++ b/src/components/directives/loginButton.less
@@ -31,4 +31,16 @@
       margin-top: -3px;
     }
   }
+  .coi-button {
+    margin: 8px 16px;
+    a {
+      background-color: #F00;
+      color: #FFF;
+    }
+    a:hover {
+      background-color: #F66;
+      color: #FFF;
+    }
+  }
+
 }

--- a/src/components/directives/loginButton.tpl.html
+++ b/src/components/directives/loginButton.tpl.html
@@ -5,9 +5,15 @@
         type="button"
         class="btn btn-xs btn-info"
         ui-sref="users.profile({userId: currentUser.id})">
-        <span class="avatar" style="background-color: transparent">
+        <span class="avatar"
+          ng-if="showCoiNotice"
+          style="background-color: transparent">
           <i class="glyphicon glyphicon-exclamation-sign" style="color: #F00;"></i>
-          <!-- <img ng-src="{{currentUser.avatars.x14}}" width="14" height="14"/> -->
+        </span>
+        <span class="avatar"
+          ng-if="!showCoiNotice"
+          style="background-color: transparent">
+          <img ng-src="{{currentUser.avatars.x14}}" width="14" height="14"/>
         </span>
         <span class="username">{{currentUser.display_name}}</span>
       </button>
@@ -51,9 +57,10 @@
         <li class="dropdown-header">Account</li>
         <li><a ui-sref="account.notifications({category: 'all', page: 1, count: 10, show_read: false, show_unlinkable: false})">My Account</a></li>
         <li><a ng-click="logout(currentUrl)">Sign Out</a></li>
-        <li class="coi-button">
+        <li class="coi-button" ng-if="showCoiNotice">
           <a ui-sref="account.profile" class="badge badge-pill badge-danger">
-            Click to update Editor COI Statement
+            <i class="glyphicon glyphicon-hand-up"></i>&nbsp;
+            Please Update COI Statement
           </a>
         </li>
       </ul>

--- a/src/components/directives/loginButton.tpl.html
+++ b/src/components/directives/loginButton.tpl.html
@@ -5,9 +5,10 @@
         type="button"
         class="btn btn-xs btn-info"
         ui-sref="users.profile({userId: currentUser.id})">
-          <span class="avatar">
-            <img ng-src="{{currentUser.avatars.x14}}" width="14" height="14"/>
-          </span>
+        <span class="avatar" style="background-color: transparent">
+          <i class="glyphicon glyphicon-exclamation-sign" style="color: #F00;"></i>
+          <!-- <img ng-src="{{currentUser.avatars.x14}}" width="14" height="14"/> -->
+        </span>
         <span class="username">{{currentUser.display_name}}</span>
       </button>
       <button type="button" class="btn btn-xs btn-info dropdown-toggle" uib-dropdown-toggle>
@@ -18,7 +19,7 @@
         <li ng-if="hasNotifications" class="dropdown-header">Notifications<br/>
         </li>
         <li ng-if="count > 0"
-            ng-repeat="(label, count) in currentUser.unread_notifications">
+          ng-repeat="(label, count) in currentUser.unread_notifications">
           <a ui-sref="account.notifications({category: '{{label}}', page: 1, count: 10, show_read: false, show_unlinkable: false})">
             <span ng-bind="label | keyToLabel">type</span>
             <span ng-bind="count" class="badge">count</span>
@@ -50,7 +51,11 @@
         <li class="dropdown-header">Account</li>
         <li><a ui-sref="account.notifications({category: 'all', page: 1, count: 10, show_read: false, show_unlinkable: false})">My Account</a></li>
         <li><a ng-click="logout(currentUrl)">Sign Out</a></li>
-
+        <li class="coi-button">
+          <a ui-sref="account.profile" class="badge badge-pill badge-danger">
+            Click to update Editor COI Statement
+          </a>
+        </li>
       </ul>
     </div>
   </div>

--- a/src/components/forms/fieldTypes/basicFieldTypes.js
+++ b/src/components/forms/fieldTypes/basicFieldTypes.js
@@ -67,6 +67,18 @@
       wrapper: ['horizontalBootstrapHelpNoLabel', 'bootstrapHasError']
     });
 
+    // radio
+    formlyConfigProvider.setType({
+      name: 'horizontalRadio',
+      extends: 'radio',
+      wrapper: ['horizontalBootstrapCheckbox', 'bootstrapHasError']
+    });
+
+    formlyConfigProvider.setType({
+      name: 'horizontalRadioHelp',
+      extends: 'radio',
+      wrapper: ['horizontalBootstrapHelpNoLabel', 'bootstrapHasError']
+    });
     // formlyConfigProvider.setType({
     //   name: 'horizontalCommentHelp',
     //   extends: 'comment',

--- a/src/components/services/CurrentUserService.js
+++ b/src/components/services/CurrentUserService.js
@@ -38,6 +38,16 @@
           isArray: false,
           cache: false
         },
+        getCoiStatements: {
+          url:'/api/current_user/conflict_of_interest_statements',
+          isArray: true,
+          cache: false
+        },
+        addCoiStatement: {
+          method: 'POST',
+          url:'/api/current_user/conflict_of_interest_statements',
+          cache: false
+        },
         markFeed: {
           method: 'PATCH',
           url: '/api/current_user/feed',
@@ -61,7 +71,7 @@
           url: '/api/current_user/feed',
           isArray: false,
           cache: false
-        }
+        },
 
       }
     );
@@ -70,6 +80,7 @@
   // @ngInject
   function CurrentUserService(CurrentUserResource, Security, _) {
     var user = {};
+    var statements = [];
     var events = [];
     var stats = [];
     var feed = {
@@ -82,6 +93,7 @@
     return {
       data: {
         user: user,
+        statements: statements,
         events: events,
         stats: stats,
         feed: feed,
@@ -91,6 +103,8 @@
       getStats: getStats,
       getEvents: getEvents,
       getFeed: getFeed,
+      getCoiStatements: getCoiStatements,
+      addCoiStatement: addCoiStatement,
       markAllAsRead: markAllAsRead,
       markFeed: markFeed
     };
@@ -128,6 +142,23 @@
       return CurrentUserResource.getFeed(reqObj).$promise
         .then(function(response) {
           angular.copy(response, feed);
+          return response.$promise;
+        });
+    }
+
+    function getCoiStatements() {
+      return CurrentUserResource.getCoiStatements().$promise
+        .then(function(response) {
+          angular.copy(response, statements);
+          return response.$promise;
+        });
+    }
+
+    function addCoiStatement(reqObj) {
+      return CurrentUserResource.addCoiStatement(reqObj).$promise
+        .then(function(response) {
+          Security.reloadCurrentUser();
+          getCoiStatements();
           return response.$promise;
         });
     }

--- a/src/components/services/CurrentUserService.js
+++ b/src/components/services/CurrentUserService.js
@@ -157,7 +157,7 @@
     function addCoiStatement(reqObj) {
       return CurrentUserResource.addCoiStatement(reqObj).$promise
         .then(function(response) {
-          Security.reloadCurrentUser();
+          get();
           getCoiStatements();
           return response.$promise;
         });

--- a/src/components/services/CurrentUserService.js
+++ b/src/components/services/CurrentUserService.js
@@ -159,6 +159,7 @@
         .then(function(response) {
           get();
           getCoiStatements();
+          Security.reloadCurrentUser();
           return response.$promise;
         });
     }

--- a/src/components/services/CurrentUserService.js
+++ b/src/components/services/CurrentUserService.js
@@ -159,7 +159,7 @@
         .then(function(response) {
           get();
           getCoiStatements();
-          Security.reloadCurrentUser();
+          Security.reloadCurrentUser(); // required to update user button in header
           return response.$promise;
         });
     }


### PR DESCRIPTION
This PR implements a variety of features that require editors to have a current conflict of interest statement in order to perform moderation actions:

- added COI form to bottom of profile edit page, allowing users to specify the absence or presence of conflicts, and describe them
- if COI is missing or expired, editor moderation action buttons are disabled, instead showing a notice to submit an updated COI
- user button in the header replaces user avatar with red notice icon (shown on every page), and a red 'update COI' button appears in the account dropdown

Closes #1180. Requires griffithlab/civic-server#531.
