### PR TITLE
Add `Dominant Negative` clinical significance

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -271,6 +271,7 @@
               { value: 'Loss of Function', label: 'Loss of Function'},
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
+              { value: 'Dominant Negative', label: 'Dominant Negative' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]
@@ -490,6 +491,7 @@
               { value: 'Loss of Function', label: 'Loss of Function'},
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
+              { value: 'Dominant Negative', label: 'Dominant Negative' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/common/assertionGrid/assertionGrid.js
+++ b/src/app/views/events/common/assertionGrid/assertionGrid.js
@@ -231,6 +231,7 @@
               { value: 'Loss of Function', label: 'Loss of Function'},
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
+              { value: 'Dominant Negative', label: 'Dominant Negative' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/common/evidenceGrid.js
+++ b/src/app/views/events/common/evidenceGrid.js
@@ -335,6 +335,7 @@
               { value: 'Loss of Function', label: 'Loss of Function'},
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
+              { value: 'Dominant Negative', label: 'Dominant Negative' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/common/evidenceGridClinicalSignificanceCell.tpl.html
+++ b/src/app/views/events/common/evidenceGridClinicalSignificanceCell.tpl.html
@@ -25,6 +25,7 @@
     'glyphicon-download' : row.entity[col.field] === 'Loss of Function',
     'glyphicon-resize-horizontal' : row.entity[col.field] === 'Unaltered Function',
     'glyphicon-exclamation-sign' : row.entity[col.field] === 'Neomorphic',
+    'glyphicon-resize-full' : row.entity[col.field] === 'Dominant Negative',
     'glyphicon-log-out' : row.entity[col.field] === 'Unknown',}">
   </span>
 </div>

--- a/src/app/views/events/common/evidenceGridPopoverKey.tpl.html
+++ b/src/app/views/events/common/evidenceGridPopoverKey.tpl.html
@@ -478,6 +478,14 @@
               </tr>
               <tr>
                 <td class="symbol clinicalCell">
+                  <span class="glyphicon glyphicon-resize-full"></span>
+                </td>
+                <td class="symbol-description">
+                  Dominant Negative
+                </td>
+              </tr>
+              <tr>
+                <td class="symbol clinicalCell">
                   <span class="glyphicon glyphicon-log-out"></span>
                 </td>
                 <td class="symbol-description">

--- a/src/app/views/events/common/evidenceSelector/evidenceSelector.js
+++ b/src/app/views/events/common/evidenceSelector/evidenceSelector.js
@@ -319,6 +319,7 @@
               { value: 'Loss of Function', label: 'Loss of Function'},
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
+              { value: 'Dominant Negative', label: 'Dominant Negative' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]
@@ -529,6 +530,7 @@
               { value: 'Loss of Function', label: 'Loss of Function'},
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
+              { value: 'Dominant Negative', label: 'Dominant Negative' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/search/config/AssertionFieldConfig.js
+++ b/src/app/views/search/config/AssertionFieldConfig.js
@@ -439,6 +439,7 @@
                         { value: 'Loss of Function', name: 'Loss of Function'},
                         { value: 'Unaltered Function', name: 'Unaltered Function'},
                         { value: 'Neomorphic', name: 'Neomorphic'},
+                        { value: 'Dominant Negative', name: 'Dominant Negative' },
                         { value: 'Unknown', name: 'Unknown'},
                         { value: 'N/A', name: 'N/A' }
                       ]

--- a/src/app/views/search/config/EvidenceItemFieldConfig.js
+++ b/src/app/views/search/config/EvidenceItemFieldConfig.js
@@ -523,6 +523,7 @@
                     { value: 'Loss of Function', name: 'Loss of Function'},
                     { value: 'Unaltered Function', name: 'Unaltered Function'},
                     { value: 'Neomorphic', name: 'Neomorphic'},
+                    { value: 'Dominant Negative', name: 'Dominant Negative' },
                     { value: 'Unknown', name: 'Unknown'},
                     { value: 'N/A', name: 'N/A' }
                   ]

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -404,6 +404,7 @@
               'Loss of Function': 'A sequence variant whereby the gene product has diminished or abolished function',
               'Unaltered Function': 'A sequence variant whereby the function of the gene product is unchanged',
               'Neomorphic': 'TBD',
+              'Dominant Negative': 'TBD',
               'Unknown': 'A functional variant that cannot be precisely defined by gain-of-function, loss-of-function, or unaltered function',
             },
           },


### PR DESCRIPTION
I picked the glyphicon-resize-full glyphicon for this but if we want something different, let me know (see https://getbootstrap.com/docs/3.3/components/). We also still need a tooltip text for Dominant Negative as well as Neomorphic.

Requires https://github.com/griffithlab/civic-server/pull/537
Closes #1189 