### PR TITLE
updated contacts section, fixed old genome web links

### DIFF
--- a/src/app/pages/contact.tpl.html
+++ b/src/app/pages/contact.tpl.html
@@ -17,7 +17,10 @@
             <dd><a href="https://www.linkedin.com/pub/nicholas-spies/49/699/75a">LinkedIn profile</a></dd>
             <br>
             <dt>Kilannin Krysiak, PhD - Lead Curator</dt>
-            <dd><a href="http://genome.wustl.edu/people/individual/kilannin-krysiak/">Genome Institute profile</a></dd>
+            <dd><a href="https://griffithlab.org/team/#Postdoctoral_Researchers">Griffith Lab profile</a></dd>
+            <br>
+            <dt>Arpad Danos, PhD - Lead Curator</dt>
+            <dd><a href="https://griffithlab.org/team/#Postdoctoral_Researchers">Griffith Lab profile</a></dd>
             <br>
             <dt>Adam Coffman - Lead Web/Software (Back End) Developer</dt>
             <dd><a href="https://github.com/acoffman">GitHub Profile</a></dd>
@@ -26,10 +29,10 @@
             <dd><a href="https://github.com/susannasiebert">GitHub Profile</a></dd>
             <br>
             <dt>Josh McMichael - Lead User Experience (Front End) Developer</dt>
-            <dd><a href="http://genome.wustl.edu/people/individual/joshua-mcmichael/">Genome Institute profile</a>, <a href="https://github.com/jmcmichael">GitHub Profile</a></dd>
+            <dd><a href="https://github.com/jmcmichael">GitHub Profile</a></dd>
             <br>
             <dt>Other WashU team members</dt>
-            <dd>Benjamin Ainscough, Erica Barnell, Katie Campbell, Kaitlin Clark, Arpad Danos, Lynzey Kujan, Cody Ramirez, Zachary Skidmore, Alex Wagner. For a complete list of curators, refer to the <a ui-sref="community.main">Community Page</a>.</dd>
+            <dd>Benjamin Ainscough, Erica Barnell, Katie Campbell, Kaitlin Clark, Lynzey Kujan, Cody Ramirez, Zachary Skidmore, Alex Wagner. For a complete list of curators, refer to the <a ui-sref="community.main">Community Page</a>.</dd>
             <br>
             <dt>Other developers</dt>
             <dd><a href="https://github.com/JonChristensen">Jon Christensen</a>, <a href="https://github.com/gkarthik">Karthik Gangavarapu</a></dd>
@@ -41,10 +44,10 @@
             <dd><a href="https://cancer.osu.edu/research-and-education/find-a-researcher/search-researcher-directory/elaine-r-mardis">OSU James profile</a></dd>
             <br>
             <dt>Malachi Griffith, PhD - PI/Mentor, Funding</dt>
-            <dd><a href="http://genome.wustl.edu/people/individual/malachi-griffith/">Genome Institute profile</a></dd>
+            <dd><a href="https://www.genome.wustl.edu/people/malachi-griffith/">Genome Institute profile</a></dd>
             <br>
             <dt>Obi Griffith, PhD - PI/Mentor, Funding</dt>
-            <dd><a href="http://genome.wustl.edu/people/individual/obi-griffith/">Genome Institute profile</a></dd>
+            <dd><a href="https://www.genome.wustl.edu/people/obi-griffith/">Genome Institute profile</a></dd>
             <br>
             <br>
             <dt>News and updates:</dt>


### PR DESCRIPTION
Moved Arpad up to Lead Curator, fixed a few links to the old genome.wustl.edu website.