### PR TITLE
drug field typeahead queries updated to handle new drug suggestions schema

### DIFF
--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -494,7 +494,7 @@
             wrapper: null,
             templateOptions: {
               typeahead: 'item.name for item in options.data.typeaheadSearch($viewValue)',
-              // focus: true,
+              templateUrl: 'components/forms/fieldTypes/drugTypeahead.tpl.html',
               onSelect: 'options.data.pushNew(model, index)',
               editable: false
             },

--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -496,17 +496,24 @@
               typeahead: 'item.name for item in options.data.typeaheadSearch($viewValue)',
               // focus: true,
               onSelect: 'options.data.pushNew(model, index)',
-              editable: true
+              editable: false
             },
             data: {
               pushNew: function(model, index) {
                 model.splice(index+1, 0, '');
               },
               typeaheadSearch: function(val) {
-                return DrugSuggestions.localQuery(val)
+                return DrugSuggestions.query(val)
                   .then(function(response) {
-                    return _.map(response, function(drugname) {
-                      return { name: drugname };
+                    var labelLimit = 70;
+                    return _.map(response, function(drug) {
+                      if (drug.aliases.length > 0) {
+                        drug.alias_list = drug.aliases.join(', ');
+                        if(drug.alias_list.length > labelLimit) { drug.alias_list = _.truncate(drug.alias_list, labelLimit); }
+                      } else {
+                        drug.alias_list = '--';
+                      }
+                      return drug;
                     });
                   });
               }

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -141,7 +141,7 @@
             typeaheadSearch: function(val) {
               return Genes.beginsWith(val)
                 .then(function(response) {
-                  var labelLimit = 70;
+                  var labelLimit = 100;
                   var list = _.map(response, function(gene) {
                     if (gene.aliases.length > 0) {
                       gene.alias_list = gene.aliases.join(', ');
@@ -681,9 +681,9 @@
             wrapper: null,
             templateOptions: {
               typeahead: 'item.name for item in options.data.typeaheadSearch($viewValue)',
-              // focus: true,
+              templateUrl: 'components/forms/fieldTypes/drugTypeahead.tpl.html',
               onSelect: 'options.data.pushNew(model, index)',
-              editable: true
+              editable: false
             },
             data: {
               pushNew: function(model, index) {
@@ -692,8 +692,15 @@
               typeaheadSearch: function(val) {
                 return DrugSuggestions.query(val)
                   .then(function(response) {
-                    return _.map(response, function(drugname) {
-                      return { name: drugname };
+                    var labelLimit = 100;
+                    return _.map(response, function(drug) {
+                      if (drug.aliases.length > 0) {
+                        drug.alias_list = drug.aliases.join(', ');
+                        if(drug.alias_list.length > labelLimit) { drug.alias_list = _.truncate(drug.alias_list, labelLimit); }
+                      } else {
+                        drug.alias_list = '--';
+                      }
+                      return drug;
                     });
                   });
               }

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -69,6 +69,7 @@
 
     vm.assertionEdit = angular.copy(vm.assertion);
     vm.assertionEdit.comment = { title: 'ASSERTION ' + vm.assertion.name + ' Revision Description', text:'' };
+    vm.assertionEdit.drugs = _.filter(_.map(vm.assertion.drugs, 'name'), function(name){ return name !== 'N/A'; });
 
     vm.styles = AssertionsViewOptions.styles;
 
@@ -492,16 +493,16 @@
             wrapper: null,
             templateOptions: {
               typeahead: 'item.name for item in options.data.typeaheadSearch($viewValue)',
-              // focus: true,
+              templateUrl: 'components/forms/fieldTypes/drugTypeahead.tpl.html',
               onSelect: 'options.data.pushNew(model, index)',
-              editable: true
+              editable: false
             },
             data: {
               pushNew: function(model, index) {
                 model.splice(index+1, 0, '');
               },
               typeaheadSearch: function(val) {
-                return DrugSuggestions.localQuery(val)
+                return DrugSuggestions.query(val)
                   .then(function(response) {
                     var labelLimit = 70;
                     return _.map(response, function(drug) {

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -503,8 +503,15 @@
               typeaheadSearch: function(val) {
                 return DrugSuggestions.localQuery(val)
                   .then(function(response) {
-                    return _.map(response, function(drugname) {
-                      return { name: drugname };
+                    var labelLimit = 70;
+                    return _.map(response, function(drug) {
+                      if (drug.aliases.length > 0) {
+                        drug.alias_list = drug.aliases.join(', ');
+                        if(drug.alias_list.length > labelLimit) { drug.alias_list = _.truncate(drug.alias_list, labelLimit); }
+                      } else {
+                        drug.alias_list = '--';
+                      }
+                      return drug;
                     });
                   });
               }

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -456,7 +456,8 @@
             templateOptions: {
               inputFormatter: 'model[options.key]',
               typeahead: 'item.name for item in options.data.typeaheadSearch($viewValue)',
-              editable: true,
+              templateUrl: 'components/forms/fieldTypes/drugTypeahead.tpl.html',
+              editable: false,
               // focus: true,
               onSelect: 'options.data.pushNew(model, index)'
             },
@@ -467,9 +468,17 @@
               typeaheadSearch: function(val) {
                 return DrugSuggestions.query(val)
                   .then(function(response) {
-                    return _.map(response, function(drugname) {
-                      return { name: drugname };
+                    var labelLimit = 70;
+                    return _.map(response, function(drug) {
+                      if (drug.aliases.length > 0) {
+                        drug.alias_list = drug.aliases.join(', ');
+                        if(drug.alias_list.length > labelLimit) { drug.alias_list = _.truncate(drug.alias_list, labelLimit); }
+                      } else {
+                        drug.alias_list = '--';
+                      }
+                      return drug;
                     });
+
                   });
               }
             }
@@ -508,7 +517,7 @@
         },
         hideExpression: function($viewValue, $modelValue, scope) {
           return !(scope.model.evidence_type === 'Predictive' && // evidence type must be predictive
-            _.without(scope.model.drugs, '').length > 1);
+                   _.without(scope.model.drugs, '').length > 1);
 
         }
       },

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -458,7 +458,6 @@
               typeahead: 'item.name for item in options.data.typeaheadSearch($viewValue)',
               templateUrl: 'components/forms/fieldTypes/drugTypeahead.tpl.html',
               editable: false,
-              // focus: true,
               onSelect: 'options.data.pushNew(model, index)'
             },
             data: {

--- a/src/components/forms/fieldTypes/drugTypeahead.tpl.html
+++ b/src/components/forms/fieldTypes/drugTypeahead.tpl.html
@@ -1,0 +1,5 @@
+<a tabindex="-1">
+  <span ng-bind-html="match.model.name | uibTypeaheadHighlight:query">NAME</span>
+  <span style="color: #AAA;">(NCIT ID: {{match.model.ncit_id}}) -- Aliases: </span>
+  <span ng-bind-html="match.model.alias_list | uibTypeaheadHighlight:query">ALIASES</span>
+</a>


### PR DESCRIPTION
The drug name suggestions API now returns objects w/ NCIT IDs and aliases, the typeahead control's query logic and templates needed to be updated on the add/edit evidence/assertion forms.

One major behavioral difference with this update is that users will be unable to enter their own drug names into these fields - they must choose an option returned from the server and displayed in the typeahead. Previously we'd allowed users to enter arbitrary strings in the drug field. We're discussing adding a Suggest Drug form to add new drugs, as a multi-input field where a user can either choose a supplied name or enter their own could be relatively complex and confusing.