### PR TITLE
toggle off excel export options in evidence grid context menu

### DIFF
--- a/src/app/views/events/common/evidenceGrid.js
+++ b/src/app/views/events/common/evidenceGrid.js
@@ -100,6 +100,7 @@
       exporterMenuCsv: false,
       exporterMenuPdf: false,
       enableGridMenu: true,
+      exporterMenuExcel: false,
       gridMenuShowHideColumns: false,
       rowTemplate: 'app/views/events/common/evidenceGridRowTemplate.tpl.html',
       gridMenuCustomItems: [


### PR DESCRIPTION
UI-grid component included these excel export options in an update, and as our CSV export feature provides the same functionality (and it works), I'm toggling off the excel export options in the context menu.

Closes #1235 