### PR TITLE
multi-input form control now allows users to create new entities with popover form

### DIFF
--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -491,7 +491,9 @@
           label: 'Drug(s)',
           inputOptions: {
             type: 'typeahead',
-            wrapper: null,
+            entityName: 'Drug',
+            showAddButton: true,
+            addFormTemplate: 'components/forms/fieldTypes/multiInputAddDrugForm.tpl.html',
             templateOptions: {
               typeahead: 'item.name for item in options.data.typeaheadSearch($viewValue)',
               templateUrl: 'components/forms/fieldTypes/drugTypeahead.tpl.html',
@@ -577,7 +579,7 @@
         templateOptions: {
           label: 'ACMG Code(s)',
           entityName: 'ACMG Code',
-          data: { message: '' },
+          showAddButton: false,
           inputOptions: {
             type: 'typeahead',
             wrapper: ['acmgDescription'],
@@ -599,7 +601,8 @@
                   });
               }
             }
-          }
+          },
+          data: { message: '' }
         },
         expressionProperties: {
           // isUnique: function (viewValue, modelValue, scope) {
@@ -613,13 +616,15 @@
         },
         hideExpression: function($viewValue, $modelValue, scope) {
           return  scope.model.evidence_type !== 'Predisposing';
-        }
+        },
       },
       {
         key: 'phenotypes',
         type: 'multiInput',
         templateOptions: {
           label: 'Associated Phenotypes',
+          entityName: 'Phenotype',
+          showAddButton: false,
           inputOptions: {
             type: 'typeahead',
             wrapper: null,

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -678,6 +678,7 @@
         type: 'multiInput',
         templateOptions: {
           label: 'Drug Names',
+          entityName: 'Drug',
           inputOptions: {
             type: 'typeahead',
             wrapper: null,

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -679,6 +679,7 @@
         templateOptions: {
           label: 'Drug Names',
           entityName: 'Drug',
+          showAddButton: false,
           inputOptions: {
             type: 'typeahead',
             wrapper: null,

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -679,7 +679,8 @@
         templateOptions: {
           label: 'Drug Names',
           entityName: 'Drug',
-          showAddButton: false,
+          showAddButton: true,
+          addFormTemplate: 'components/forms/fieldTypes/multiInputAddDrugForm.tpl.html',
           inputOptions: {
             type: 'typeahead',
             wrapper: null,

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -747,6 +747,8 @@
         type: 'multiInput',
         templateOptions: {
           label: 'Associated Phenotypes',
+          entityName: 'Phenotype',
+          showAddButton: false,
           inputOptions: {
             type: 'typeahead',
             wrapper: null,

--- a/src/app/views/add/evidence/addEvidenceBasic.tpl.html
+++ b/src/app/views/add/evidence/addEvidenceBasic.tpl.html
@@ -90,21 +90,21 @@
     </div>
   </div>
 
-  <div class="row">
-    <div class="col-xs-4">
-      <h3>vm.newEvidence</h3>
-      <pre ng-bind="vm.newEvidence|json" class="small"></pre>
-      <h3>submit button stuff</h3>
-      <p>vm.form.$invalid: {{vm.form.$invalid}}</p>
-      <p>vm.isAuthenticated: {{vm.isAuthenticated}}</p>
-    </div>
-    <div class="col-xs-4">
-      <h3>vm.form</h3>
-      <pre ng-bind="vm.form|json" class="small"></pre>
-    </div>
-    <div class="col-xs-4">
-      <h3>vm.evidenceFields</h3>
-      <pre ng-bind="vm.evidenceFields|json" class="small"></pre>
-    </div>
-  </div>
+  <!-- <div class="row"> -->
+  <!-- <div class="col-xs-4"> -->
+  <!-- <h3>vm.newEvidence</h3> -->
+  <!-- <pre ng-bind="vm.newEvidence|json" class="small"></pre> -->
+  <!-- <h3>submit button stuff</h3> -->
+  <!-- <p>vm.form.$invalid: {{vm.form.$invalid}}</p> -->
+  <!-- <p>vm.isAuthenticated: {{vm.isAuthenticated}}</p> -->
+  <!-- </div> -->
+  <!-- <div class="col-xs-4"> -->
+  <!-- <h3>vm.form</h3> -->
+  <!-- <pre ng-bind="vm.form|json" class="small"></pre> -->
+  <!-- </div> -->
+  <!-- <div class="col-xs-4"> -->
+  <!-- <h3>vm.evidenceFields</h3> -->
+  <!-- <pre ng-bind="vm.evidenceFields|json" class="small"></pre> -->
+  <!-- </div> -->
+  <!-- </div> -->
 </div>

--- a/src/app/views/add/evidence/addEvidenceBasic.tpl.html
+++ b/src/app/views/add/evidence/addEvidenceBasic.tpl.html
@@ -90,21 +90,21 @@
     </div>
   </div>
 
-  <!-- <div class="row"> -->
-  <!-- <div class="col-xs-4"> -->
-  <!-- <h3>vm.newEvidence</h3> -->
-  <!-- <pre ng-bind="vm.newEvidence|json" class="small"></pre> -->
-  <!-- <h3>submit button stuff</h3> -->
-  <!-- <p>vm.form.$invalid: {{vm.form.$invalid}}</p> -->
-  <!-- <p>vm.isAuthenticated: {{vm.isAuthenticated}}</p> -->
-  <!-- </div> -->
-  <!-- <div class="col-xs-4"> -->
-  <!-- <h3>vm.form</h3> -->
-  <!-- <pre ng-bind="vm.form|json" class="small"></pre> -->
-  <!-- </div> -->
-  <!-- <div class="col-xs-4"> -->
-  <!-- <h3>vm.evidenceFields</h3> -->
-  <!-- <pre ng-bind="vm.evidenceFields|json" class="small"></pre> -->
-  <!-- </div> -->
-  <!-- </div> -->
+  <div class="row">
+    <div class="col-xs-4">
+      <h3>vm.newEvidence</h3>
+      <pre ng-bind="vm.newEvidence|json" class="small"></pre>
+      <h3>submit button stuff</h3>
+      <p>vm.form.$invalid: {{vm.form.$invalid}}</p>
+      <p>vm.isAuthenticated: {{vm.isAuthenticated}}</p>
+    </div>
+    <div class="col-xs-4">
+      <h3>vm.form</h3>
+      <pre ng-bind="vm.form|json" class="small"></pre>
+    </div>
+    <div class="col-xs-4">
+      <h3>vm.evidenceFields</h3>
+      <pre ng-bind="vm.evidenceFields|json" class="small"></pre>
+    </div>
+  </div>
 </div>

--- a/src/app/views/add/variantGroup/addVariantGroup.js
+++ b/src/app/views/add/variantGroup/addVariantGroup.js
@@ -121,7 +121,7 @@
         templateOptions: {
           label: 'Variants',
           entityName: 'Variant',
-          helpText: 'Click the X button to delete a variant, click the + button to add a variant. Note that variants must be known to CIViC to be available for including here. New variants may be added as part of an evidence item using the <a href="/add/evidence/basic" target="_self">Add Evidence form</a>.',
+          showAddButton: false,
           inputOptions: {
             type: 'typeahead',
             wrapper: null,
@@ -149,7 +149,8 @@
                   });
               }
             }
-          }
+          },
+          helpText: 'Click the X button to delete a variant, click the + button to add a variant. Note that variants must be known to CIViC to be available for including here. New variants may be added as part of an evidence item using the <a href="/add/evidence/basic" target="_self">Add Evidence form</a>.',
         }
       }
     ];

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -487,7 +487,10 @@
         key: 'drugs',
         type: 'multiInput',
         templateOptions: {
-          label: 'Drug(s)',
+          label: 'Drug Name(s)',
+          entityName: 'Drug',
+          showAddButton: true,
+          addFormTemplate: 'components/forms/fieldTypes/multiInputAddDrugForm.tpl.html',
           inputOptions: {
             type: 'typeahead',
             wrapper: null,
@@ -575,6 +578,8 @@
         type: 'multiInput',
         templateOptions: {
           label: 'Associated Phenotypes',
+          entityName: 'Phenotype',
+          showAddButton: false,
           inputOptions: {
             type: 'typeahead',
             wrapper: null,
@@ -608,6 +613,7 @@
         templateOptions: {
           label: 'ACMG Code(s)',
           entityName: 'ACMG Code',
+          showAddButton: false,
           data: { message: '' },
           inputOptions: {
             type: 'typeahead',

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -460,8 +460,8 @@
               inputFormatter: 'model[options.key]',
               typeahead: 'item.name for item in options.data.typeaheadSearch($viewValue)',
               templateUrl: 'components/forms/fieldTypes/drugTypeahead.tpl.html',
+              onSelect: 'options.data.pushNew(model, index)',
               editable: false,
-              onSelect: 'options.data.pushNew(model, index)'
             },
             data: {
               pushNew: function(model, index) {

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -450,6 +450,9 @@
         type: 'multiInput',
         templateOptions: {
           label: 'Drug Names',
+          entityName: 'Drug',
+          showAddButton: true,
+          addFormTemplate: 'components/forms/fieldTypes/multiInputAddDrugForm.tpl.html',
           inputOptions: {
             type: 'typeahead',
             wrapper: null,
@@ -525,6 +528,8 @@
         type: 'multiInput',
         templateOptions: {
           label: 'Associated Phenotypes',
+          entityName: 'Phenotype',
+          showAddButton: false,
           inputOptions: {
             type: 'typeahead',
             wrapper: null,

--- a/src/app/views/events/genes/edit/geneEditBasic.js
+++ b/src/app/views/events/genes/edit/geneEditBasic.js
@@ -115,6 +115,7 @@
           label: 'Sources',
           helpText: 'Please specify the Pubmed IDs of any sources used as references in the Gene Summary.',
           entityName: 'Source',
+          showAddButton: false,
           inputOptions: {
             type: 'publication-multi',
             templateOptions: {

--- a/src/app/views/events/variantGroups/edit/variantGroupEditBasic.js
+++ b/src/app/views/events/variantGroups/edit/variantGroupEditBasic.js
@@ -98,6 +98,7 @@
           label: 'Sources',
           helpText: 'Please specify the Pubmed IDs of any sources used as references in the Variant Group Summary.',
           entityName: 'Source',
+          showAddButton: false,
           inputOptions: {
             type: 'publication-multi',
             templateOptions: {
@@ -156,6 +157,7 @@
         templateOptions: {
           label: 'Variants',
           entityName: 'Variant',
+          showAddButton: false,
           helpText: 'Click the X button to delete a variant, click the + button to add a variant. Note that variants must be known to CIViC to be available for including here. New variants may be added as part of an evidence item using the <a href="/add/evidence/basic" target="_self">Add Evidence form</a>.',
           inputOptions: {
             type: 'typeahead',

--- a/src/app/views/events/variants/edit/variantEditBasic.js
+++ b/src/app/views/events/variants/edit/variantEditBasic.js
@@ -110,8 +110,9 @@
         type: 'multiInput',
         templateOptions: {
           label: 'Aliases',
-          helpText: 'Please specify any aliases commonly used to refer to this variant.',
           entityName: 'Alias',
+          showAddButton: false,
+          helpText: 'Please specify any aliases commonly used to refer to this variant.',
           required: false,
           inputOptions: {
             type: 'basicInput',
@@ -129,9 +130,10 @@
         type: 'multiInput',
         templateOptions: {
           label: 'HGVS Expressions',
-          helpText: 'Please specify any HGVS expressions for this variant.',
-          entityName: 'HGVS Expression',
           required: false,
+          entityName: 'Expression',
+          showAddButton: false,
+          helpText: 'Please specify any HGVS expressions for this variant.',
           inputOptions: {
             type: 'basicInput',
             wrapper: '',
@@ -148,9 +150,10 @@
         type: 'multiInput',
         templateOptions: {
           label: 'ClinVar IDs',
-          helpText: 'Please specify any corresponding ClinVar identifiers for this variant.',
-          entityName: 'ClinVar ID',
           required: false,
+          helpText: 'Please specify any corresponding ClinVar identifiers for this variant.',
+          entityName: 'ID',
+          showAddButton: false,
           inputOptions: {
             type: 'basicInput',
             wrapper: '',
@@ -237,6 +240,7 @@
           label: 'Sources',
           helpText: 'Please specify the Pubmed IDs of any sources used as references in the Variant Summary.',
           entityName: 'Source',
+          showAddButton: false,
           inputOptions: {
             type: 'publication-multi',
             templateOptions: {
@@ -296,6 +300,7 @@
           label: 'Variant Type(s)',
           helpText: 'Add one or more variant types from the <a href="http://www.sequenceontology.org/browser/" title="Opens a new tab for the Sequence Ontology Browser" target="_blank">Sequence Ontology</a> (e.g., missense, loss-of-function).',
           entityName: 'Type',
+          showAddButton: false,
           inputOptions: {
             type: 'typeahead',
             wrapper: ['simpleHasError', 'validationMessages'],

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -30,8 +30,6 @@
     vm.showSuccess = false;
     vm.showConflict = false;
 
-    vm.conflictDrug = null;
-
     vm.newDrug = {
       drug_name: ''
     };
@@ -53,6 +51,7 @@
         .then(
           function(response) { // success
             console.log('Drug successfully added.');
+            vm.createdDrug = response;
             vm.showForm = false;
             vm.showSuccess = true;
           },

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -17,12 +17,18 @@
 
   function addDrugFormController($rootScope,
                                  $scope,
+                                 DrugService,
                                  ConfigService,
                                  _) {
     var vm = $scope.vm = { };
     vm.parentField = _.find($scope.fields, { key: $scope.options.key }); // field object ref
     vm.index = $scope.$index; // $index value assigned by angular-formly
     vm.replaceItem = $scope.replaceItem; // replaceItem on multiInput controller
+    vm.suggestions = [];
+
+    vm.showForm = true;
+    vm.showSuccess = false;
+    vm.showConflict = false;
 
     vm.newDrug = {
       name: ''
@@ -39,9 +45,17 @@
       }
     ];
 
-    vm.submit = function(newDrug) {
+    vm.submit = function() {
       console.log('new drug submitted.');
-      vm.replaceItem(this.parentField.value(), this.index, newDrug.name);
+      DrugsService.add(this.newDrug.name)
+        .then(function(response) {
+          console.log('drug added successfully');
+        });
+      vm.replaceItem(this.parentField.value(), this.index, this.newDrug.name);
+    };
+
+    vm.replaceItem = function(newDrug) {
+      vm.replaceItem(this.parentField.value(), this.index, this.newDrug.name);
     };
   }
 })();

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -76,8 +76,8 @@
     };
 
     vm.addDrug= function() {
-      console.log('Replacing model drug name.');
-      vm.replaceItem(this.parentField.value(), this.index, vm.createdDrug.name);
+      var drug = vm.createdDrug ? vm.createdDrug.name : vm.conflictDrug.name;
+      vm.replaceItem(this.parentField.value(), this.index, drug);
     };
   }
 })();

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -17,7 +17,7 @@
 
   function addDrugFormController($rootScope,
                                  $scope,
-                                 DrugService,
+                                 Drugs,
                                  ConfigService,
                                  _) {
     var vm = $scope.vm = { };
@@ -31,12 +31,12 @@
     vm.showConflict = false;
 
     vm.newDrug = {
-      name: ''
+      drug_name: ''
     };
 
     vm.newDrugFields = [
       {
-        key: 'name',
+        key: 'drug_name',
         type: 'input',
         templateOptions: {
           label: 'Drug Name',
@@ -47,14 +47,22 @@
 
     vm.submit = function() {
       console.log('new drug submitted.');
-      DrugsService.add(this.newDrug.name)
-        .then(function(response) {
-          console.log('drug added successfully');
-        });
-      vm.replaceItem(this.parentField.value(), this.index, this.newDrug.name);
+      Drugs.add(this.newDrug)
+        .then(
+          function(response) { // success
+            console.log('Drug successfully added.');
+            vm.showForm = false;
+            vm.showSuccess = true;
+          },
+          function(response) {
+            console.log('Error adding new drug.');
+            vm.showForm = false;
+            vm.showError = true;
+          });
     };
 
-    vm.replaceItem = function(newDrug) {
+    vm.replaceItem = function() {
+      console.log('Replacing model drug name.');
       vm.replaceItem(this.parentField.value(), this.index, this.newDrug.name);
     };
   }

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -9,16 +9,20 @@
       restrict: 'E',
       templateUrl: 'components/directives/addDrugForm.tpl.html',
       replace: true,
-      scope: {},
       controller: addDrugFormController
     };
 
     return directive;
   }
 
-  function addDrugFormController($scope,
-                                 ConfigService) {
-    var vm = $scope.vm = {};
+  function addDrugFormController($rootScope,
+                                 $scope,
+                                 ConfigService,
+                                 _) {
+    var vm = $scope.vm = { };
+    vm.parentField = _.find($scope.fields, { key: $scope.options.key }); // field object ref
+    vm.index = $scope.$index; // $index value assigned by angular-formly
+    vm.replaceItem = $scope.replaceItem; // replaceItem on multiInput controller
 
     vm.newDrug = {
       name: ''
@@ -35,8 +39,9 @@
       }
     ];
 
-    vm.submit = function(newDrug, options) {
-      console.log('New Drug Submitted');
+    vm.submit = function(newDrug) {
+      console.log('new drug submitted.');
+      vm.replaceItem(this.parentField.value(), this.index, newDrug.name);
     };
   }
 })();

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -30,6 +30,8 @@
     vm.showSuccess = false;
     vm.showConflict = false;
 
+    vm.conflictDrug = null;
+
     vm.newDrug = {
       drug_name: ''
     };
@@ -56,14 +58,23 @@
           },
           function(response) {
             console.log('Error adding new drug.');
+            var status = vm.errorStatus = response.status;
             vm.showForm = false;
-            vm.showError = true;
+            vm.showConflict = true;
+            switch(status) {
+            case 409: // conflict, drug exists.
+              vm.conflictDrug = response.data;
+              break;
+            case 500: // server error
+              break;
+            default: // general error
+            }
           });
     };
 
-    vm.replaceItem = function() {
+    vm.addDrug= function() {
       console.log('Replacing model drug name.');
-      vm.replaceItem(this.parentField.value(), this.index, this.newDrug.name);
+      vm.replaceItem(this.parentField.value(), this.index, this.newDrug.drug_name);
     };
   }
 })();

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -20,14 +20,14 @@
                                  ConfigService) {
     var vm = $scope.vm = {};
 
-    var newDrug = {
+    vm.newDrug = {
       name: ''
     };
 
-    var newDrugFields = [
+    vm.newDrugFields = [
       {
         key: 'name',
-        type: 'horizontalTypeahead',
+        type: 'horizontalInput',
         wrapper: null,
         templateOptions: {
           label: 'Drug Name',

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -21,9 +21,9 @@
                                  ConfigService,
                                  _) {
     var vm = $scope.vm = { };
-    vm.parentField = _.find($scope.fields, { key: $scope.options.key }); // field object ref
+    vm.parentField = _.find($scope.fields, { key: $scope.options.key }); // ref to parent's form field object
     vm.index = $scope.$index; // $index value assigned by angular-formly
-    vm.replaceItem = $scope.replaceItem; // replaceItem on multiInput controller
+    vm.replaceItem = $scope.replaceItem; // ref to replaceItem function on multiInput controller
     vm.suggestions = [];
 
     vm.showForm = true;
@@ -44,6 +44,10 @@
         }
       }
     ];
+
+    vm.close = function() {
+      $scope.$parent.addFormIsOpen = false;
+    };
 
     vm.submit = function() {
       console.log('new drug submitted.');

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -7,16 +7,37 @@
   function addDrugForm() {
     var directive = {
       restrict: 'E',
-      template: '<div>{{message}}</div>',
+      templateUrl: 'components/directives/addDrugForm.tpl.html',
       replace: true,
-      scope: true,
+      scope: {},
       controller: addDrugFormController
     };
 
     return directive;
   }
 
-  function addDrugFormController($scope, ConfigService) {
-    $scope.message = 'This is the addDrugForm directive.';
+  function addDrugFormController($scope,
+                                 ConfigService) {
+    var vm = $scope.vm = {};
+
+    var newDrug = {
+      name: ''
+    };
+
+    var newDrugFields = [
+      {
+        key: 'name',
+        type: 'horizontalTypeahead',
+        wrapper: null,
+        templateOptions: {
+          label: 'Drug Name',
+          required: true
+        }
+      }
+    ];
+
+    vm.submit = function(newDrug, options) {
+      console.log('New Drug Submitted');
+    };
   }
 })();

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -77,7 +77,7 @@
 
     vm.addDrug= function() {
       console.log('Replacing model drug name.');
-      vm.replaceItem(this.parentField.value(), this.index, this.newDrug.drug_name);
+      vm.replaceItem(this.parentField.value(), this.index, vm.createdDrug.name);
     };
   }
 })();

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -1,0 +1,22 @@
+(function() {
+  'use strict';
+  angular.module('civic.common')
+    .directive('addDrugForm', addDrugForm);
+
+  // @ngInject
+  function addDrugForm() {
+    var directive = {
+      restrict: 'E',
+      template: '<div>{{message}}</div>',
+      replace: true,
+      scope: true,
+      controller: addDrugFormController
+    };
+
+    return directive;
+  }
+
+  function addDrugFormController($scope, ConfigService) {
+    $scope.message = 'This is the addDrugForm directive.';
+  }
+})();

--- a/src/components/directives/addDrugForm.js
+++ b/src/components/directives/addDrugForm.js
@@ -27,8 +27,7 @@
     vm.newDrugFields = [
       {
         key: 'name',
-        type: 'horizontalInput',
-        wrapper: null,
+        type: 'input',
         templateOptions: {
           label: 'Drug Name',
           required: true

--- a/src/components/directives/addDrugForm.less
+++ b/src/components/directives/addDrugForm.less
@@ -1,2 +1,5 @@
 .addDrugForm {
+  form {
+    padding: 0 16px;
+  }
 }

--- a/src/components/directives/addDrugForm.less
+++ b/src/components/directives/addDrugForm.less
@@ -1,0 +1,2 @@
+.addDrugForm {
+}

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -1,32 +1,38 @@
 <div class="addDrugForm">
-  <div class="row" >
-    <div class="col-xs-12" >
-      <p class="small" >
-        Please enter a new drug name, then press the Create button.
-      </p>
+  <div>
+    <!-- <div ng-if="vm.showForm"> -->
+    <div class="row" >
+      <div class="col-xs-12" >
+        <p class="small" >
+          Please enter a new drug name, then press the Create button.
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-12">
+        <form class="form-horizontal" name="vm.form" autocomplete="off" novalidate>
+          <formly-form options="vm.options" model="vm.newDrug" fields="vm.newDrugFields">
+
+          </formly-form>
+        </form>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-xs-6" >
+        <cancel-button></cancel-button>
+      </div>
+      <div class="col-xs-6">
+        <button type="submit"
+          class="btn btn-success pull-right"
+          ng-disabled="vm.form.$invalid"
+          ng-click="vm.submit(vm.newDrug, vm.parentModel, vm.parentField)">
+          Create
+        </button>
+      </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-xs-12">
-      <form class="form-horizontal" name="vm.form" autocomplete="off" novalidate>
-        <formly-form options="vm.options" model="vm.newDrug" fields="vm.newDrugFields">
-
-        </formly-form>
-      </form>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-xs-6" >
-      <cancel-button></cancel-button>
-    </div>
-    <div class="col-xs-6">
-      <button type="submit"
-        class="btn btn-success pull-right"
-        ng-disabled="vm.form.$invalid"
-        ng-click="vm.submit(vm.newDrug, vm.options)">
-        Create
-      </button>
-    </div>
+  <div ng-if="vm.showSuccess" >
+    <p>Success!</p>
   </div>
 </div>

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -1,3 +1,27 @@
 <div class="addDrugForm">
-  Add Drug Form directive.
+  <div class="addDrugForm">
+    <div class="row">
+      <div class="col-xs-12" >
+        <form class="form-horizontal" name="vm.form" autocomplete="off" novalidate>
+          <formly-form options="vm.options" model="vm.newDrug" fields="vm.newDrugFields">
+
+          </formly-form>
+        </form>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-xs-6" >
+        <cancel-button></cancel-button>
+      </div>
+      <div class="col-xs-6" >
+        <button type="submit"
+          class="btn btn-default"
+          ng-disabled="vm.form.$invalid"
+          ng-click="vm.submit(vm.newDrug, vm.options)">
+          Create New Drug
+        </button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -1,7 +1,6 @@
 <div class="addDrugForm">
-  <div>
-    <!-- <div ng-if="vm.showForm"> -->
-    <div class="row" >
+  <div ng-if="vm.showForm">
+    <div class="row">
       <div class="col-xs-12" >
         <p class="small" >
           Please enter a new drug name, then press the Create button.
@@ -32,13 +31,34 @@
       </div>
     </div>
   </div>
-  <div ng-if="vm.showSuccess" >
-    <p>Success!</p>
+  <div ng-if="vm.showSuccess" class="row">
+    <div class="col-xs-12">
+      <div class="alert alert-success" role="alert">
+        <strong>Success:</strong>
+        {{vm.conflictDrug.name}} successfully added to CIViC.
+      </div>
+    </div>
+    <div class="col-xs-12">
+      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.conflictDrug.name}}</strong> to Drug List</button>
+    </div>
   </div>
-  <div ng-if="vm.showConflict" >
-    <p>Conflict!</p>
+  <div ng-if="vm.showConflict" class="row">
+    <div class="col-xs-12">
+      <div class="alert alert-warning" role="alert">
+        <strong>Conflict:</strong>
+        A drug named {{vm.conflictDrug.name}} already exists in the CIViC database.
+      </div>
+    </div>
+    <div class="col-xs-12">
+      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.conflictDrug.name}}</strong> Drug List</button>
+    </div>
   </div>
-  <div ng-if="vm.showError" >
-    <p>Error!</p>
+  <div ng-if="vm.showError" class="row">
+    <div class="col-xs-12">
+      <div class="alert alert-danger" role="alert">
+        <strong>Error:</strong>
+        An unknown server error occurred. Please check the browser console for more information and report an issue if the problem persists.
+      </div>
+    </div>
   </div>
 </div>

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -1,0 +1,3 @@
+<div class="addDrugForm">
+  {{message}}
+</div>

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="col-xs-12">
-      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.conflictDrug.name}}</strong> Drug List</button>
+      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.conflictDrug.name}}</strong> to Drug List</button>
     </div>
   </div>
   <div ng-if="vm.showError" class="row">

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -19,6 +19,11 @@
 
     <div class="row">
       <div class="col-xs-6" >
+        <button type="button"
+          class="btn btn-sm btn-default pull-left"
+          ng-click="vm.close()">
+          Cancel
+        </button>
       </div>
       <div class="col-xs-6">
         <button type="submit"

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -1,3 +1,3 @@
 <div class="addDrugForm">
-  {{message}}
+  Add Drug Form directive.
 </div>

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -26,7 +26,7 @@
         <button type="submit"
           class="btn btn-success pull-right"
           ng-disabled="vm.form.$invalid"
-          ng-click="vm.submit(vm.newDrug, vm.parentModel, vm.parentField)">
+          ng-click="vm.submit(vm.newDrug)">
           Create
         </button>
       </div>

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -1,27 +1,32 @@
 <div class="addDrugForm">
-  <div class="addDrugForm">
-    <div class="row">
-      <div class="col-xs-12" >
-        <form class="form-horizontal" name="vm.form" autocomplete="off" novalidate>
-          <formly-form options="vm.options" model="vm.newDrug" fields="vm.newDrugFields">
-
-          </formly-form>
-        </form>
-      </div>
+  <div class="row" >
+    <div class="col-xs-12" >
+      <p class="small" >
+        Please enter a new drug name, then press the Create button.
+      </p>
     </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <form class="form-horizontal" name="vm.form" autocomplete="off" novalidate>
+        <formly-form options="vm.options" model="vm.newDrug" fields="vm.newDrugFields">
 
-    <div class="row">
-      <div class="col-xs-6" >
-        <cancel-button></cancel-button>
-      </div>
-      <div class="col-xs-6" >
-        <button type="submit"
-          class="btn btn-default"
-          ng-disabled="vm.form.$invalid"
-          ng-click="vm.submit(vm.newDrug, vm.options)">
-          Create New Drug
-        </button>
-      </div>
+        </formly-form>
+      </form>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-6" >
+      <cancel-button></cancel-button>
+    </div>
+    <div class="col-xs-6">
+      <button type="submit"
+        class="btn btn-success pull-right"
+        ng-disabled="vm.form.$invalid"
+        ng-click="vm.submit(vm.newDrug, vm.options)">
+        Create
+      </button>
     </div>
   </div>
 </div>

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -39,7 +39,7 @@
       </div>
     </div>
     <div class="col-xs-12">
-      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.createdDrug.name}}</strong> to Drug List</button>
+      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.createdDrug.name}}</strong> to Drug Names</button>
     </div>
   </div>
   <div ng-if="vm.showConflict" class="row">
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="col-xs-12">
-      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.conflictDrug.name}}</strong> to Drug List</button>
+      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.conflictDrug.name}}</strong> to Drug Names</button>
     </div>
   </div>
   <div ng-if="vm.showError" class="row">

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -26,7 +26,7 @@
         </button>
       </div>
       <div class="col-xs-6">
-        <button type="submit"
+        <button type="button"
           class="btn btn-sm btn-success pull-right"
           ng-disabled="vm.form.$invalid"
           ng-click="vm.submit(vm.newDrug)">

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -19,11 +19,10 @@
 
     <div class="row">
       <div class="col-xs-6" >
-        <cancel-button></cancel-button>
       </div>
       <div class="col-xs-6">
         <button type="submit"
-          class="btn btn-success pull-right"
+          class="btn btn-sm btn-success pull-right"
           ng-disabled="vm.form.$invalid"
           ng-click="vm.submit(vm.newDrug)">
           Create

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -35,4 +35,10 @@
   <div ng-if="vm.showSuccess" >
     <p>Success!</p>
   </div>
+  <div ng-if="vm.showConflict" >
+    <p>Conflict!</p>
+  </div>
+  <div ng-if="vm.showError" >
+    <p>Error!</p>
+  </div>
 </div>

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -35,18 +35,18 @@
     <div class="col-xs-12">
       <div class="alert alert-success" role="alert">
         <strong>Success:</strong>
-        {{vm.conflictDrug.name}} successfully added to CIViC.
+        New drug <strong>{{vm.createdDrug.name}}</strong> was created.
       </div>
     </div>
     <div class="col-xs-12">
-      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.conflictDrug.name}}</strong> to Drug List</button>
+      <button class="btn btn-block btn-sm btn-success" ng-click="vm.addDrug()">Add <strong>{{vm.createdDrug.name}}</strong> to Drug List</button>
     </div>
   </div>
   <div ng-if="vm.showConflict" class="row">
     <div class="col-xs-12">
       <div class="alert alert-warning" role="alert">
         <strong>Conflict:</strong>
-        A drug named {{vm.conflictDrug.name}} already exists in the CIViC database.
+        A drug named <strong>{{vm.conflictDrug.name}}</strong> already exists in the CIViC database.
       </div>
     </div>
     <div class="col-xs-12">

--- a/src/components/directives/addDrugForm.tpl.html
+++ b/src/components/directives/addDrugForm.tpl.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-xs-12" >
         <p class="small" >
-          Please enter a new drug name, then press the Create button.
+          Use this form to add a new drug name to CIViC. Please ensure that the new drug name is inclued in the <a href="https://ncithesaurus.nci.nih.gov/ncitbrowser/pages/advanced_search.jsf?dictionary=NCI%20Thesaurus" alt="NCIthesaurus Advanced Search" target="_blank">NCIt database</a>.
         </p>
       </div>
     </div>

--- a/src/components/forms/fieldTypes/multiInput.js
+++ b/src/components/forms/fieldTypes/multiInput.js
@@ -19,6 +19,7 @@
       },
       controller: /* @ngInject */ function($scope) {
         $scope.copyItemOptions = copyItemOptions;
+        $scope.replaceItem = replaceItem;
         $scope.deleteItem = deleteItem;
         $scope.addItem = addItem;
 
@@ -28,6 +29,10 @@
 
         function addItem(model, index) {
           model.splice(index+1, 0, '');
+        }
+
+        function replaceItem(model, index, value) {
+          model[index] = value;
         }
 
         function copyItemOptions() {

--- a/src/components/forms/fieldTypes/multiInput.less
+++ b/src/components/forms/fieldTypes/multiInput.less
@@ -1,0 +1,5 @@
+.multiInput {
+  .popover {
+    min-width: 450px;
+  }
+}

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -19,6 +19,7 @@
             tooltip-placement="bottom"
             tooltip-append-to-body="true"
             uib-popover-template="'{{to.addFormTemplate}}'"
+            popover-trigger="outsideClick"
             popover-title="Create New {{to.entityName}}"
             popover-append-to-body="false"
             ng-if="model[options.key][$index] === ''">

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -19,6 +19,7 @@
             tooltip-placement="bottom"
             tooltip-append-to-body="true"
             uib-popover-template="'{{to.addFormTemplate}}'"
+            popover-title="Create New {{to.entityName}}"
             popover-append-to-body="false"
             ng-if="model[options.key][$index] === ''">
             <span class="glyphicon glyphicon-edit"></span>

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -2,8 +2,8 @@
   <div class="clearfix">
     <div ng-repeat="item in model[options.key] track by $index"
       ng-init="itemOptions = copyItemOptions()">
-      <div class="row">
-        <div class="col-xs-9">
+      <div class="row" style="margin-bottom: 8px;">
+        <div class="col-md-8 col-lg-9">
           <formly-field class="no-padding"
             options="itemOptions"
             model="model[options.key]"
@@ -14,21 +14,25 @@
         <div class="col-xs-1" style="margin-top:6px; text-align: right;">
           <button
             type="button"
-            class="btn btn-danger btn-xs"
+            class="btn btn-default btn-xs"
+            uib-tooltip="Create New Drug"
+            ng-if="model[options.key][$index] === ''"
             ng-click="deleteItem(model[options.key], $index)">
-            <span class="glyphicon glyphicon-remove"></span>
+            <span class="glyphicon glyphicon-edit"></span>
           </button>
         </div>
-        <div class="col-xs-2" style="margin-top:6px; padding-left: 0px; text-align: right;">
+        <div class="col-md-3 col-lg-2" style="margin-top:6px; padding-left: 0px; text-align: right;">
           <button
             type="button"
             class="btn btn-danger btn-xs"
+            uib-tooltip="Remove Drug Row"
             ng-click="deleteItem(model[options.key], $index)">
             <span class="glyphicon glyphicon-remove"></span>
           </button>
           <button
             type="button"
             class="btn btn-success btn-xs"
+            uib-tooltip="Add Drug Row"
             ng-if="$index + 1 === model[options.key].length"
             ng-click="model[options.key].push('')">
             <span class="glyphicon glyphicon-plus"></span> </button>

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -1,4 +1,4 @@
-<div style="margin-bottom:14px">
+<div class="multiInput" style="margin-bottom:14px">
   <div class="clearfix">
     <div ng-repeat="item in model[options.key] track by $index"
       ng-init="itemOptions = copyItemOptions()">
@@ -17,7 +17,7 @@
             class="btn btn-default btn-xs"
             uib-tooltip="Create New {{to.entityName}}"
             uib-popover-template="'{{to.addFormTemplate}}'"
-            popover-append-to-body="true"
+            popover-append-to-body="false"
             ng-if="model[options.key][$index] === ''">
             <span class="glyphicon glyphicon-edit"></span>
           </button>

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -1,7 +1,7 @@
 <div class="multiInput" style="margin-bottom:14px">
   <div class="clearfix">
     <div ng-repeat="item in model[options.key] track by $index"
-      ng-init="itemOptions = copyItemOptions()">
+      ng-init="itemOptions = copyItemOptions(); addFormIsOpen = false;">
       <div class="row" style="margin-bottom: 8px;">
         <div class="col-md-8 col-lg-9">
           <formly-field class="no-padding"
@@ -20,6 +20,7 @@
             tooltip-append-to-body="true"
             uib-popover-template="'{{to.addFormTemplate}}'"
             popover-trigger="outsideClick"
+            popover-is-open="addFormIsOpen"
             popover-title="Create New {{to.entityName}}"
             popover-append-to-body="false"
             ng-if="model[options.key][$index] === ''">

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -16,8 +16,9 @@
             type="button"
             class="btn btn-default btn-xs"
             uib-tooltip="Create New {{to.entityName}}"
-            ng-if="model[options.key][$index] === ''"
-            ng-click="deleteItem(model[options.key], $index)">
+            uib-popover-template="{{to.addFormTemplate}}"
+            popover-append-to-body="true"
+            ng-if="model[options.key][$index] === ''">
             <span class="glyphicon glyphicon-edit"></span>
           </button>
         </div>

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -1,39 +1,47 @@
-<div>
+<div style="margin-bottom:14px">
   <div class="clearfix">
-    <div class="row"
-         style="margin-bottom:14px"
-         ng-repeat="item in model[options.key] track by $index"
-         ng-init="itemOptions = copyItemOptions()">
-      <div class="col-xs-9">
-        <formly-field class="no-padding"
-                      options="itemOptions"
-                      model="model[options.key]"
-                      form="form"
-                      index="$index">
-        </formly-field>
-      </div>
-      <div class="col-xs-3" style="margin-top:6px">
-        <button
-          type="button"
-          class="btn btn-danger btn-xs"
-          ng-click="deleteItem(model[options.key], $index)">
-          <span class="glyphicon glyphicon-remove"></span>
-        </button>
-        <button
-          type="button"
-          class="btn btn-success btn-xs"
-          ng-if="$index + 1 === model[options.key].length"
-          ng-click="model[options.key].push('')">
-          <span class="glyphicon glyphicon-plus"></span> </button>
-        </button>
+    <div ng-repeat="item in model[options.key] track by $index"
+      ng-init="itemOptions = copyItemOptions()">
+      <div class="row">
+        <div class="col-xs-9">
+          <formly-field class="no-padding"
+            options="itemOptions"
+            model="model[options.key]"
+            form="form"
+            index="$index">
+          </formly-field>
+        </div>
+        <div class="col-xs-1" style="margin-top:6px; text-align: right;">
+          <button
+            type="button"
+            class="btn btn-danger btn-xs"
+            ng-click="deleteItem(model[options.key], $index)">
+            <span class="glyphicon glyphicon-remove"></span>
+          </button>
+        </div>
+        <div class="col-xs-2" style="margin-top:6px; padding-left: 0px; text-align: right;">
+          <button
+            type="button"
+            class="btn btn-danger btn-xs"
+            ng-click="deleteItem(model[options.key], $index)">
+            <span class="glyphicon glyphicon-remove"></span>
+          </button>
+          <button
+            type="button"
+            class="btn btn-success btn-xs"
+            ng-if="$index + 1 === model[options.key].length"
+            ng-click="model[options.key].push('')">
+            <span class="glyphicon glyphicon-plus"></span> </button>
+          </button>
+        </div>
       </div>
     </div>
   </div>
   <div class="row" ng-if="model[options.key].length === 0">
     <div class="col-xs-12">
       <button type="button"
-              class="btn btn-success btn-sm btn-block"
-              ng-click="model[options.key].push('')">
+        class="btn btn-success btn-sm btn-block"
+        ng-click="model[options.key].push('')">
         Add {{ to.entityName }}
       </button>
     </div>

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -16,6 +16,8 @@
             type="button"
             class="btn btn-default btn-xs"
             uib-tooltip="Create New {{to.entityName}}"
+            tooltip-placement="bottom"
+            tooltip-append-to-body="true"
             uib-popover-template="'{{to.addFormTemplate}}'"
             popover-append-to-body="false"
             ng-if="model[options.key][$index] === ''">
@@ -26,7 +28,9 @@
           <button
             type="button"
             class="btn btn-danger btn-xs"
-            uib-tooltip="Remove Drug Row"
+            uib-tooltip="Remove {{to.entityName}} Row"
+            tooltip-placement="bottom"
+            tooltip-append-to-body="true"
             ng-click="deleteItem(model[options.key], $index)">
             <span class="glyphicon glyphicon-remove"></span>
           </button>
@@ -34,6 +38,8 @@
             type="button"
             class="btn btn-success btn-xs"
             uib-tooltip="Add {{to.entityName}} Row"
+            tooltip-placement="bottom"
+            tooltip-append-to-body="true"
             ng-if="$index + 1 === model[options.key].length"
             ng-click="model[options.key].push('')">
             <span class="glyphicon glyphicon-plus"></span> </button>

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -11,11 +11,11 @@
             index="$index">
           </formly-field>
         </div>
-        <div class="col-xs-1" style="margin-top:6px; text-align: right;">
+        <div class="col-xs-1" ng-if="to.showAddButton" style="margin-top:6px; text-align: right;">
           <button
             type="button"
             class="btn btn-default btn-xs"
-            uib-tooltip="Create New Drug"
+            uib-tooltip="Create New {{to.entityName}}"
             ng-if="model[options.key][$index] === ''"
             ng-click="deleteItem(model[options.key], $index)">
             <span class="glyphicon glyphicon-edit"></span>
@@ -32,7 +32,7 @@
           <button
             type="button"
             class="btn btn-success btn-xs"
-            uib-tooltip="Add Drug Row"
+            uib-tooltip="Add {{to.entityName}} Row"
             ng-if="$index + 1 === model[options.key].length"
             ng-click="model[options.key].push('')">
             <span class="glyphicon glyphicon-plus"></span> </button>

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -23,7 +23,7 @@
             popover-is-open="addFormIsOpen"
             popover-title="Create New {{to.entityName}}"
             popover-append-to-body="false"
-            ng-if="model[options.key][$index] === ''">
+            ng-if="!model[options.key][$index]">
             <span class="glyphicon glyphicon-edit"></span>
           </button>
         </div>

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -19,7 +19,7 @@
             tooltip-placement="bottom"
             tooltip-append-to-body="true"
             uib-popover-template="'{{to.addFormTemplate}}'"
-            popover-trigger="outsideClick"
+            popover-trigger="'outsideClick'"
             popover-is-open="addFormIsOpen"
             popover-title="Create New {{to.entityName}}"
             popover-append-to-body="false"

--- a/src/components/forms/fieldTypes/multiInput.tpl.html
+++ b/src/components/forms/fieldTypes/multiInput.tpl.html
@@ -16,7 +16,7 @@
             type="button"
             class="btn btn-default btn-xs"
             uib-tooltip="Create New {{to.entityName}}"
-            uib-popover-template="{{to.addFormTemplate}}"
+            uib-popover-template="'{{to.addFormTemplate}}'"
             popover-append-to-body="true"
             ng-if="model[options.key][$index] === ''">
             <span class="glyphicon glyphicon-edit"></span>

--- a/src/components/forms/fieldTypes/multiInputAddDrugForm.tpl.html
+++ b/src/components/forms/fieldTypes/multiInputAddDrugForm.tpl.html
@@ -1,0 +1,1 @@
+<add-drug-form></add-drug-form>

--- a/src/components/forms/fieldTypes/multiInputAddDrugForm.tpl.html
+++ b/src/components/forms/fieldTypes/multiInputAddDrugForm.tpl.html
@@ -1,3 +1,1 @@
-<div>
-  <add-drug-form></add-drug-form>
-</div>
+<add-drug-form></add-drug-form>

--- a/src/components/forms/fieldTypes/multiInputAddDrugForm.tpl.html
+++ b/src/components/forms/fieldTypes/multiInputAddDrugForm.tpl.html
@@ -1,1 +1,3 @@
-<add-drug-form></add-drug-form>
+<div>
+  <add-drug-form></add-drug-form>
+</div>

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -455,7 +455,7 @@
         'Evidence Level' : 'Type of study performed to produce the evidence statement',
         'Evidence Direction' : 'An indicator of whether the evidence statement supports or refutes the clinical significance of an event. Evidence Type must be selected before this field is enabled.',
         'Clinical Significance' : 'Positive or negative association of the Variant with predictive, prognostic, diagnostic, or predisposing evidence types. If the variant was not associated with a positive or negative outcome, N/A should be selected. Evidence Type must be selected before this field is enabled.',
-        'Drug Names' : 'For predictive evidence, specify one or more drug names. Drugs specified must possess a PubChem ID (e.g., 44462760 for Dabrafenib).',
+        'Drug Names' : 'For predictive evidence, specify one or more drug names. If the name cannot be found in CIViC\'s database, you may create a new one by clicking on the button adjacent to the input box and following the instructions.',
         'Drug Interaction Type' : 'Please indicate whether the drugs specified above are substitutes, or are used in sequential or combination treatments.',
         'Phenotypes' : 'Please provide any <a href="http://compbio.charite.de/hpoweb/showterm?id=HP:0000118" target="_blank">HPO phenotypes.</a>',
         'Rating' : 'Please rate your evidence on a scale of one to five stars. Use the star rating descriptions for guidance.',

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -455,7 +455,7 @@
         'Evidence Level' : 'Type of study performed to produce the evidence statement',
         'Evidence Direction' : 'An indicator of whether the evidence statement supports or refutes the clinical significance of an event. Evidence Type must be selected before this field is enabled.',
         'Clinical Significance' : 'Positive or negative association of the Variant with predictive, prognostic, diagnostic, or predisposing evidence types. If the variant was not associated with a positive or negative outcome, N/A should be selected. Evidence Type must be selected before this field is enabled.',
-        'Drug Names' : 'For predictive evidence, specify one or more drug names. If the name cannot be found in CIViC\'s database, you may create a new one by clicking on the button adjacent to the input box and following the instructions.',
+        'Drug Names' : 'For predictive evidence, specify one or more drug names. If the type-ahead list does not display your drug\'s name or alias, it likely does not exist in CIViC\'s database. You may click the button adjacent to the input box to show the Add Drug form and add a new drug to the database.',
         'Drug Interaction Type' : 'Please indicate whether the drugs specified above are substitutes, or are used in sequential or combination treatments.',
         'Phenotypes' : 'Please provide any <a href="http://compbio.charite.de/hpoweb/showterm?id=HP:0000118" target="_blank">HPO phenotypes.</a>',
         'Rating' : 'Please rate your evidence on a scale of one to five stars. Use the star rating descriptions for guidance.',

--- a/src/components/services/DrugService.js
+++ b/src/components/services/DrugService.js
@@ -6,7 +6,7 @@
     .factory('Drugs', DrugsService);
 
   // @ngInject
-  function DrugsResource($resource) {
+  function DrugsResource($resource, $cacheFactory) {
     var cache = $cacheFactory.get('$http');
 
     return $resource('/api/drugs/:drugId', {}, {
@@ -34,7 +34,7 @@
   }
 
   // @ngInject
-  function DrugsService(DrugsResource) {
+  function DrugsService(DrugsResource, $cacheFactory) {
     var cache = $cacheFactory.get('$http');
     // base Drug and Drug Colletion
     var item = {},
@@ -71,8 +71,8 @@
         });
     }
 
-    function add(reqObj) {
-      return DrugsResource.add(reqObj).$promise
+    function add(newDrug) {
+      return DrugsResource.add(newDrug).$promise
         .then(function(response) {
           return response.$promise;
         });
@@ -89,12 +89,6 @@
         });
     };
 
-    function add(reqObj) {
-      return DrugsResource.add(reqObj).$promise
-        .then(function(response) {
-          return response.$promise;
-        });
-    }
 
   };
 

--- a/src/components/services/DrugService.js
+++ b/src/components/services/DrugService.js
@@ -1,0 +1,51 @@
+(function() {
+  'use strict';
+
+  angular.module('civic.services')
+    .factory('DrugsResource', DrugsResource)
+    .factory('Drugs', DrugsService);
+
+  // @ngInject
+  function DrugsResource($resource) {
+    return $resource('/api/drugs', {}, {
+      querySuggestions: {
+        url: '/api/drugs/suggestions',
+        method: 'GET',
+        isArray: true,
+        cache: false
+      }
+    });
+  }
+
+  // @ngInject
+  function DrugsService(DrugsResource) {
+    var cache = $cacheFactory.get('$http');
+    // base Drug and Drug Colletion
+    var item = {},
+        collection = [],
+        suggestions = [];
+
+
+    return {
+      data: {
+        item: item,
+        collection: collection,
+        suggestions: suggestions
+      },
+
+      querySuggestions: querySuggestions,
+
+    };
+  };
+
+  var querySuggestions = function(str) {
+    var reqObj = {
+      q: str
+    };
+    return DrugsResource.querySuggestions(reqObj).$promise
+      .then(function(response) {
+        angular.copy(response, suggestions);
+        return response.$promise;
+      });
+  };
+})();

--- a/src/components/services/DrugService.js
+++ b/src/components/services/DrugService.js
@@ -7,7 +7,23 @@
 
   // @ngInject
   function DrugsResource($resource) {
-    return $resource('/api/drugs', {}, {
+    var cache = $cacheFactory.get('$http');
+
+    return $resource('/api/drugs/:drugId', {}, {
+      query: {
+        method: 'GET',
+        isArray: true,
+        cache: cache
+      },
+      get: {
+        method: 'GET',
+        isArray: false,
+        cache: cache
+      },
+      add: {
+        method: 'POST',
+        cache: false
+      },
       querySuggestions: {
         url: '/api/drugs/suggestions',
         method: 'GET',
@@ -32,20 +48,54 @@
         collection: collection,
         suggestions: suggestions
       },
-
+      query: query,
+      get: get,
+      add: add,
       querySuggestions: querySuggestions,
 
     };
+
+    function query() {
+      return DrugsResource.query().$promise
+        .then(function(response) {
+          angular.copy(response, collection);
+          return response.$promise;
+        });
+    }
+
+    function get(drugId) {
+      return DrugsResource.get({drugId: drugId}).$promise
+        .then(function(response) {
+          angular.copy(response, item);
+          return response.$promise;
+        });
+    }
+
+    function add(reqObj) {
+      return DrugsResource.add(reqObj).$promise
+        .then(function(response) {
+          return response.$promise;
+        });
+    }
+
+    function querySuggestions(str) {
+      var reqObj = {
+        q: str
+      };
+      return DrugsResource.querySuggestions(reqObj).$promise
+        .then(function(response) {
+          angular.copy(response, suggestions);
+          return response.$promise;
+        });
+    };
+
+    function add(reqObj) {
+      return DrugsResource.add(reqObj).$promise
+        .then(function(response) {
+          return response.$promise;
+        });
+    }
+
   };
 
-  var querySuggestions = function(str) {
-    var reqObj = {
-      q: str
-    };
-    return DrugsResource.querySuggestions(reqObj).$promise
-      .then(function(response) {
-        angular.copy(response, suggestions);
-        return response.$promise;
-      });
-  };
 })();


### PR DESCRIPTION
In order to allow users to create a new drug not found in the CIViC database, the multiInput form field control needed to be updated with a 'new entity' button and popover that shows a new entity form. The Add Evidence drug field has been updated to use this new feature, I'll shortly be updating the other forms that use multiInput.

New button next to the Add/Remove row buttons:
![Screenshot 2019-11-21 12 11 11](https://user-images.githubusercontent.com/132909/69364491-07753a80-0c58-11ea-85e7-876b3924b53c.png)

Displays a popover when clicked:
![Screenshot 2019-11-21 12 03 00](https://user-images.githubusercontent.com/132909/69364546-24aa0900-0c58-11ea-9d6d-0a37ca6f7ef6.png)

User enters a new drug name:
![Screenshot 2019-11-21 12 03 51](https://user-images.githubusercontent.com/132909/69364558-2d024400-0c58-11ea-91c0-1cff845a7105.png)

If new drug added successfully, confirmation msg appears along with a button allowing the user to immediately add it to the list:
![Screenshot 2019-11-21 12 03 58](https://user-images.githubusercontent.com/132909/69364631-486d4f00-0c58-11ea-80cc-20d76a4b0916.png)

After 'Add' button clicked:
![Screenshot 2019-11-21 12 04 03](https://user-images.githubusercontent.com/132909/69364649-4f945d00-0c58-11ea-9b13-077820e63e94.png)

If the new drug already exists, a conflict msg is shown, along with the same 'Add' button:
![Screenshot 2019-11-21 12 04 19](https://user-images.githubusercontent.com/132909/69364693-6470f080-0c58-11ea-8328-e761e026ee36.png)

Closes #1244, requires griffithlab/civic-server#549.