### PR TITLE
Gene and Variant summaries now show provisional text

### DIFF
--- a/src/app/views/events/genes/summary/geneDescription.tpl.html
+++ b/src/app/views/events/genes/summary/geneDescription.tpl.html
@@ -9,13 +9,29 @@
           </p>
         </div>
         <div ng-switch-default="false">
-          <p class="description">
-            This Gene does not currently have a Summary.
-          </p>
-          <div ng-if="vm.isAuthenticated() && !vm.isEdit">
-            <p>
-              <a class="btn btn-small btn-default" ui-sref="events.genes.edit.basic({ geneId: geneData.id })">Add a Summary</a>
-            </p>
+          <!-- check for provisional description -->
+          <div ng-switch="geneData.provisional_values.description || '_undefined_'">
+            <div ng-switch-when="_undefined_">
+              <p class="description">
+                This Gene does not currently have a Summary.
+              </p>
+              <div ng-if="vm.isAuthenticated() && !vm.isEdit">
+                <p>
+                  <a class="btn btn-small btn-default" ui-sref="events.genes.edit.basic({ geneId: geneData.id })">Add a Summary</a>
+                </p>
+              </div>
+            </div>
+            <div ng-switch-default>
+              <p>
+                <div class="label label-warning" style="display:block;">CAUTION: This is a provisional description from a Suggested Change not yet accepted by an Editor.</div>
+              </p>
+              <p ng-bind="geneData.provisional_values.description.value" class="description">
+                Gene Provisional Summary
+              </p>
+              <p>
+                <a ng-href="/events/genes/{{geneData.id}}/talk/revisions/list/{{geneData.provisional_values.description.revision_id}}/summary" class="btn btn-default btn-block btn-xs">View This Description's Suggested Change</a>
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -42,15 +42,31 @@
               </p>
             </div>
             <div ng-switch-default="false">
-              <p class="description">
-                This Variant does not currently have a Summary.
-              </p>
-              <div ng-if="isAuthenticated() && !isEdit">
-                <p>
-                  <a class="btn btn-small btn-default" ui-sref="events.genes.summary.variants.edit.basic({ geneId: stateParams.geneId, variantId: variant.id })">
-                    Add a Summary
-                  </a>
-                </p>
+              <!-- check for provisional description -->
+              <div ng-switch="variant.provisional_values.description || '_undefined_'">
+                <div ng-switch-when="_undefined_">
+                  <p class="description">
+                    This Variant does not currently have a Summary.
+                  </p>
+                  <div ng-if="isAuthenticated() && !isEdit">
+                    <p>
+                      <a class="btn btn-small btn-default" ui-sref="events.genes.summary.variants.edit.basic({ geneId: stateParams.geneId, variantId: variant.id })">
+                        Add a Summary
+                      </a>
+                    </p>
+                  </div>
+                </div>
+                <div ng-switch-default>
+                  <p>
+                    <div class="label label-warning" style="display:block;">CAUTION: This is a provisional description from a Suggested Change not yet accepted by an Editor.</div>
+                  </p>
+                  <p ng-bind="variant.provisional_values.description.value" class="description">
+                    Variant Provisional Summary
+                  </p>
+                  <p>
+                    <a ng-href="/events/genes/{{stateParams.geneId}}/summary/variants/{{variant.id}}/talk/revisions/list/{{variant.provisional_values.description.revision_id}}/summary" class="btn btn-default btn-block btn-xs">View This Description's Suggested Change</a>
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -73,10 +89,10 @@
                     <span  ng-if="type.display_name !== 'N/A'">
                       <a ng-href="{{ type.url }}" target="_blank">{{type.display_name}}</a>
                     </span>
-              <span ng-if="type.display_name === 'N/A'">{{type.display_name}}</span>
-              </span>
-              </span>
-              <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
+                    <span ng-if="type.display_name === 'N/A'">{{type.display_name}}</span>
+                  </span>
+                </span>
+                <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
                   None specified.
                 </span>
               </span>
@@ -96,8 +112,8 @@
                     }}
                     {{ expression }}
                   </span>
-              </span>
-              <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
+                </span>
+                <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
                   None specified.
                 </span>
               </span>
@@ -117,9 +133,9 @@
                     }}
                     <a ng-if="clinvar_ignore.indexOf(clinvar_id) == -1" ng-href="https://www.ncbi.nlm.nih.gov/clinvar/variation/{{ clinvar_id }}/" target="_blank">{{ clinvar_id }}</a>
                     <span ng-if="clinvar_ignore.indexOf(clinvar_id) !== -1">{{ clinvar_id }}</span>
-              </span>
-              </span>
-              <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
+                  </span>
+                </span>
+                <span ng-switch-when="false" class="small" style="font-style: oblique; color: #666;">
                   None specified.
                 </span>
               </span>


### PR DESCRIPTION
If a Gene or Variant suggested change exists that provides summary description text, it is displayed with a caution notice ('This is a provisional description from a Suggested Change not yet accepted by an Editor.') and a button to view the suggested change.

Closes #464 