### PR TITLE
Add Gene Entrez Alias as advanced search options

### DIFF
--- a/src/app/views/search/config/AssertionFieldConfig.js
+++ b/src/app/views/search/config/AssertionFieldConfig.js
@@ -46,6 +46,7 @@
                         { value: 'interaction_type', name: 'Drug Interaction Type' },
                         { value: 'drug_name', name: 'Drug Name' },
                         { value: 'drug_id', name: 'Drug ID' },
+                        { value: 'gene_alias', name: 'Gene Entrez Alias' },
                         { value: 'gene_name', name: 'Gene Entrez Name' },
                         { value: 'phenotype_hpo_class', name: 'Phenotype HPO Class' },
                         { value: 'phenotype_hpo_id', name: 'Phenotype HPO ID' },
@@ -735,6 +736,35 @@
                       type: 'input',
                       className: 'inline-field inline-field-xs',
                       hideExpression: 'model.name.length > 0 && model.name !== "is_in_the_range"',
+                      templateOptions: {
+                        label: '',
+                        required: true
+                      }
+                    }
+                  ],
+                  gene_alias: [
+                    {
+                      key: 'name',
+                      type: 'queryBuilderSelect',
+                      className: 'inline-field',
+                      data: {
+                        defaultValue: 'contains'
+                      },
+                      templateOptions: {
+                        label: '',
+                        required: true,
+                        options: [
+                          {value: 'is', name: 'is'},
+                          {value: 'contains', name: 'contains'},
+                          {value: 'begins_with', name: 'begins with'},
+                          {value: 'does_not_contain', name: 'does not contain'}
+                        ]
+                      }
+                    },
+                    {
+                      key: 'parameters[0]',
+                      type: 'input',
+                      className: 'inline-field',
                       templateOptions: {
                         label: '',
                         required: true

--- a/src/app/views/search/config/AssertionFieldConfig.js
+++ b/src/app/views/search/config/AssertionFieldConfig.js
@@ -46,7 +46,7 @@
                         { value: 'interaction_type', name: 'Drug Interaction Type' },
                         { value: 'drug_name', name: 'Drug Name' },
                         { value: 'drug_id', name: 'Drug ID' },
-                        { value: 'gene_name', name: 'Gene Name' },
+                        { value: 'gene_name', name: 'Gene Entrez Name' },
                         { value: 'phenotype_hpo_class', name: 'Phenotype HPO Class' },
                         { value: 'phenotype_hpo_id', name: 'Phenotype HPO ID' },
                         { value: 'status', name: 'Status' },

--- a/src/app/views/search/config/EvidenceItemFieldConfig.js
+++ b/src/app/views/search/config/EvidenceItemFieldConfig.js
@@ -39,6 +39,7 @@
                         { value: 'evidence_level', name: 'Evidence Level' },
                         { value: 'evidence_type', name: 'Evidence Type' },
                         { value: 'description', name: 'Evidence Statement' },
+                        { value: 'gene_alias', name: 'Gene Entrez Alias' },
                         { value: 'gene_name', name: 'Gene Name' },
                         { value: 'phenotype_hpo_class', name: 'Phenotype HPO Term' },
                         { value: 'phenotype_hpo_id', name: 'Phenotype HPO ID' },
@@ -947,6 +948,35 @@
                     }
                   ],
                   gene_name: [
+                    {
+                      key: 'name',
+                      type: 'queryBuilderSelect',
+                      className: 'inline-field',
+                      data: {
+                        defaultValue: 'contains'
+                      },
+                      templateOptions: {
+                        label: '',
+                        required: true,
+                        options: [
+                          {value: 'is', name: 'is'},
+                          {value: 'contains', name: 'contains'},
+                          {value: 'begins_with', name: 'begins with'},
+                          {value: 'does_not_contain', name: 'does not contain'}
+                        ]
+                      }
+                    },
+                    {
+                      key: 'parameters[0]',
+                      type: 'input',
+                      className: 'inline-field',
+                      templateOptions: {
+                        label: '',
+                        required: true
+                      }
+                    }
+                  ],
+                  gene_alias: [
                     {
                       key: 'name',
                       type: 'queryBuilderSelect',

--- a/src/app/views/search/config/EvidenceItemFieldConfig.js
+++ b/src/app/views/search/config/EvidenceItemFieldConfig.js
@@ -40,7 +40,7 @@
                         { value: 'evidence_type', name: 'Evidence Type' },
                         { value: 'description', name: 'Evidence Statement' },
                         { value: 'gene_alias', name: 'Gene Entrez Alias' },
-                        { value: 'gene_name', name: 'Gene Name' },
+                        { value: 'gene_name', name: 'Gene Entrez Name' },
                         { value: 'phenotype_hpo_class', name: 'Phenotype HPO Term' },
                         { value: 'phenotype_hpo_id', name: 'Phenotype HPO ID' },
                         { value: 'publication_year', name: 'Publication Year' },

--- a/src/app/views/search/config/GeneFieldConfig.js
+++ b/src/app/views/search/config/GeneFieldConfig.js
@@ -17,11 +17,11 @@
                       required: true,
                       options: [
                         { value: '', name: 'Please select a field' },
-                        { value: 'aliases', name: 'Aliases' },
                         { value: 'assertion_count', name: 'Assertion' },
                         { value: 'description', name: 'Description' },
+                        { value: 'aliases', name: 'Entrez Aliases' },
                         { value: 'entrez_id', name: 'Entrez ID' },
-                        { value: 'name', name: 'Name' },
+                        { value: 'name', name: 'Entrez Name' },
                         { value: 'suggested_changes_count', name: 'Suggested Revisions' }
                       ],
                       onChange: function(value, options, scope) {

--- a/src/app/views/search/config/VariantFieldConfig.js
+++ b/src/app/views/search/config/VariantFieldConfig.js
@@ -35,7 +35,7 @@
                         { value: 'disease_doid', name: 'Disease Implicated (DOID)' },
                         { value: 'ensembl_version', name: 'Ensembl Version' },
                         { value: 'evidence_item_count', name: 'Evidence Items' },
-                        { value: 'gene', name: 'Gene' },
+                        { value: 'gene', name: 'Gene Entrez Name' },
                         { value: 'hgvs_expressions', name: 'HGVS Expression(s)' },
                         { value: 'name', name: 'Name' },
                         { value: 'pipeline_type', name: 'Pipeline Type' },


### PR DESCRIPTION
This PR add Gene Entrez Alias as a search option to the evidence item and assertion advanced searches. It also renames Gene Name advanced search options to Gene Entrez Name.

Requires https://github.com/griffithlab/civic-server/pull/563
Closes #1140.