### PR TITLE
Remove any mention of PubChem ID

### DIFF
--- a/src/app/pages/help_evidence_overview.tpl.html
+++ b/src/app/pages/help_evidence_overview.tpl.html
@@ -85,9 +85,9 @@
       </tr>
       <tr>
         <td>Drug</td>
-        <td>For predictive evidence, indicates the therapy for which sensitivity or resistance is indicated (With PubChem ID or ASCO Abstract ID if available).</td>
-        <td>Tamoxifen, Raloxifene (PubChem CIDs: 2733526, 5053).</td>
-        <td>CIViC (PubChem/ASCO Abstract ID)</td>
+        <td>For predictive evidence, indicates the therapy for which sensitivity or resistance is indicated (With NCIt ID if available).</td>
+        <td>Tamoxifen, Raloxifene (NCIt IDs: C62078, C1518).</td>
+        <td>CIViC (NCIt ID)</td>
       </tr>
       <tr>
         <td>Drug Interaction Type</td>


### PR DESCRIPTION
I didn't find any actual usage of pubchem_id on the frontend.

Related to #1274 