### PR TITLE
Advanced search source grid now properly filters source type

### DIFF
--- a/src/app/views/sources/components/sourceGrid.js
+++ b/src/app/views/sources/components/sourceGrid.js
@@ -73,8 +73,8 @@
             disableCancelFilterButton: false,
             selectOptions: [
               { value: null, label: '--' },
-              { value: '0', label: 'PubMed'},
-              { value: '1', label: 'ASCO'}
+              { value: 'PubMed', label: 'PubMed'},
+              { value: 'ASCO', label: 'ASCO'}
             ]
           }
         },


### PR DESCRIPTION
 Updated filters to reflect actual values returned (used to be 0/1 instead of PubMed/ASCO?).

Closes #1102 