### PR TITLE
Add link to background queue monitoring

### DIFF
--- a/src/components/directives/loginButton.js
+++ b/src/components/directives/loginButton.js
@@ -18,6 +18,7 @@
                                            Security,
                                            ConfigService) {
         $scope.adminUrl = ConfigService.serverUrl + 'admin';
+        $scope.queuesUrl = ConfigService.serverUrl + 'api/jobs/';
         $scope.isAdmin = Security.isAdmin;
         $scope.isEditor = Security.isEditor;
         $scope.logout = Security.logout;

--- a/src/components/directives/loginButton.tpl.html
+++ b/src/components/directives/loginButton.tpl.html
@@ -52,6 +52,7 @@
         <li ng-if="isAdmin()" class="dropdown-header">Administrator Tools</li>
         <li ng-if="isAdmin()">
           <a ng-href="{{adminUrl}}" target="_blank">Admin Console</a>
+          <a ng-href="{{queuesUrl}}" target="_blank">Background Workers</a>
         </li>
 
         <li class="dropdown-header">Account</li>


### PR DESCRIPTION
If user is logged in and also an admin.

(tested locally and seems to work as expected)