### PR TITLE
NCCN Guideline field on Assertion add/edit forms switched to typeahead input instead of select

### DIFF
--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -37,6 +37,7 @@
                                   Security,
                                   Genes,
                                   Diseases,
+                                  NccnGuidelines,
                                   Phenotypes,
                                   DrugSuggestions) {
     var vm = this;
@@ -81,7 +82,9 @@
       amp_level: '',
       acmg_codes: [''],
       phenotypes: [],
-      nccn_guideline: '',
+      nccn_guideline: {
+        name: ''
+      },
       nccn_guideline_version: '',
       fda_regulatory_approval: false,
       fda_companion_test: false,
@@ -654,17 +657,37 @@
       },
       {
         key: 'nccn_guideline',
-        type: 'horizontalSelectHelp',
+        type: 'horizontalTypeaheadHelp',
+        wrapper: ['loader'],
         templateOptions: {
           label: 'NCCN Guideline',
-          options: ([{ value: '', label: 'Please select an NCCN Guideline' }].concat(_.map(nccnGuidelines, function(guideline) {
-            return { value: guideline, label: guideline};
-          }))),
-          valueProp: 'value',
-          labelProp: 'label',
-          helpText: 'If applicable, please provide cancer (e.g., Breast Cancer) and version (e.g., 5.2016) for the appropriate <a href="http://www.nccn.org/professionals/physician_gls/default.aspx#site" target="_blank">NCCN guideline</a>.'
-        }
+          value: 'vm.newEvidence.nccn_guideline',
+          required: false,
+          helpText: 'If applicable, please provide cancer (e.g., Breast Cancer) and version (e.g., 5.2016) for the appropriate <a href="http://www.nccn.org/professionals/physician_gls/default.aspx#site" target="_blank">NCCN guideline</a>.',
+          typeahead: 'item as item.name for item in to.data.typeaheadSearch($viewValue)',
+          data: {
+            typeaheadSearch: function(val) {
+              return NccnGuidelines.contains(val)
+                .then(function(response) {
+                  return response;
+                });
+            }
+          }
+        },
       },
+      // {
+      //   key: 'nccn_guideline',
+      //   type: 'horizontalSelectHelp',
+      //   templateOptions: {
+      //     label: 'NCCN Guideline',
+      //     options: ([{ value: '', label: 'Please select an NCCN Guideline' }].concat(_.map(nccnGuidelines, function(guideline) {
+      //       return { value: guideline, label: guideline};
+      //     }))),
+      //     valueProp: 'value',
+      //     labelProp: 'label',
+      //     helpText: 'If applicable, please provide cancer (e.g., Breast Cancer) and version (e.g., 5.2016) for the appropriate <a href="http://www.nccn.org/professionals/physician_gls/default.aspx#site" target="_blank">NCCN guideline</a>.'
+      //   }
+      // },
       {
         key: 'nccn_guideline_version',
         type: 'horizontalInputHelp',

--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -662,6 +662,7 @@
         templateOptions: {
           label: 'NCCN Guideline',
           value: 'vm.newEvidence.nccn_guideline',
+          editable: false,
           required: false,
           helpText: 'If applicable, please provide cancer (e.g., Breast Cancer) and version (e.g., 5.2016) for the appropriate <a href="http://www.nccn.org/professionals/physician_gls/default.aspx#site" target="_blank">NCCN guideline</a>.',
           typeahead: 'item as item.name for item in to.data.typeaheadSearch($viewValue)',

--- a/src/app/views/add/assertion/addAssertion.tpl.html
+++ b/src/app/views/add/assertion/addAssertion.tpl.html
@@ -113,14 +113,14 @@
     </div>
   </div>
 
-  <!-- <div class="row"> -->
-  <!-- <div class="col-xs-6"> -->
-  <!-- <h4>Assertion</h4> -->
-  <!-- <pre ng-bind="vm.assertion | json"></pre> -->
-  <!-- </div> -->
-  <!-- <div class="col-xs-6"> -->
-  <!-- <h4>vm.form</h4> -->
-  <!-- <pre ng-bind="vm.form | json"></pre> -->
-  <!-- </div> -->
-  <!-- </div> -->
+  <div class="row">
+    <div class="col-xs-6">
+      <h4>Assertion</h4>
+      <pre ng-bind="vm.assertion | json"></pre>
+    </div>
+    <div class="col-xs-6">
+      <h4>vm.form</h4>
+      <pre ng-bind="vm.form | json"></pre>
+    </div>
+  </div>
 </div>

--- a/src/app/views/add/assertion/addAssertion.tpl.html
+++ b/src/app/views/add/assertion/addAssertion.tpl.html
@@ -113,14 +113,14 @@
     </div>
   </div>
 
-  <div class="row">
-    <div class="col-xs-6">
-      <h4>Assertion</h4>
-      <pre ng-bind="vm.assertion | json"></pre>
-    </div>
-    <div class="col-xs-6">
-      <h4>vm.form</h4>
-      <pre ng-bind="vm.form | json"></pre>
-    </div>
-  </div>
+  <!-- <div class="row"> -->
+  <!-- <div class="col-xs-6"> -->
+  <!-- <h4>Assertion</h4> -->
+  <!-- <pre ng-bind="vm.assertion | json"></pre> -->
+  <!-- </div> -->
+  <!-- <div class="col-xs-6"> -->
+  <!-- <h4>vm.form</h4> -->
+  <!-- <pre ng-bind="vm.form | json"></pre> -->
+  <!-- </div> -->
+  <!-- </div> -->
 </div>

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -671,6 +671,7 @@
         templateOptions: {
           label: 'NCCN Guideline',
           value: 'vm.assertionEdit.nccn_guideline',
+          editable: false,
           required: false,
           helpText: 'If applicable, please provide cancer (e.g., Breast Cancer) and version (e.g., 5.2016) for the appropriate <a href="http://www.nccn.org/professionals/physician_gls/default.aspx#site" target="_blank">NCCN guideline</a>.',
           typeahead: 'item as item.name for item in to.data.typeaheadSearch($viewValue)',

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -33,6 +33,7 @@
                                    Genes,
                                    Diseases,
                                    Phenotypes,
+                                   NccnGuidelines,
                                    DrugSuggestions) {
     var assertionModel, vm;
     var acmgCodes = Assertions.data.acmg_codes;
@@ -67,9 +68,13 @@
     vm.assertionRevisions = AssertionRevisions;
     vm.assertionHistory = AssertionHistory;
 
+    // copy current assertion to edit object, adjust some attributes to what the form expects
     vm.assertionEdit = angular.copy(vm.assertion);
     vm.assertionEdit.comment = { title: 'ASSERTION ' + vm.assertion.name + ' Revision Description', text:'' };
     vm.assertionEdit.drugs = _.filter(_.map(vm.assertion.drugs, 'name'), function(name){ return name !== 'N/A'; });
+    vm.assertionEdit.nccn_guideline = {
+      name: vm.assertionEdit.nccn_guideline ? vm.assertionEdit.nccn_guideline : ''
+    };
 
     vm.styles = AssertionsViewOptions.styles;
 
@@ -661,17 +666,37 @@
       },
       {
         key: 'nccn_guideline',
-        type: 'horizontalSelectHelp',
+        type: 'horizontalTypeaheadHelp',
+        wrapper: ['loader'],
         templateOptions: {
           label: 'NCCN Guideline',
-          options: ([{ value: '', label: 'Please select an NCCN Guideline' }].concat(_.map(nccnGuidelines, function(guideline) {
-            return { value: guideline, label: guideline};
-          }))),
-          valueProp: 'value',
-          labelProp: 'label',
-          helpText: 'If applicable, please provide cancer (e.g., Breast Cancer) and version (e.g., 5.2016) for the appropriate <a href="http://www.nccn.org/professionals/physician_gls/default.aspx#site" target="_blank">NCCN guideline</a>.'
-        }
+          value: 'vm.assertionEdit.nccn_guideline',
+          required: false,
+          helpText: 'If applicable, please provide cancer (e.g., Breast Cancer) and version (e.g., 5.2016) for the appropriate <a href="http://www.nccn.org/professionals/physician_gls/default.aspx#site" target="_blank">NCCN guideline</a>.',
+          typeahead: 'item as item.name for item in to.data.typeaheadSearch($viewValue)',
+          data: {
+            typeaheadSearch: function(val) {
+              return NccnGuidelines.contains(val)
+                .then(function(response) {
+                  return response;
+                });
+            }
+          }
+        },
       },
+      // {
+      //   key: 'nccn_guideline',
+      //   type: 'horizontalSelectHelp',
+      //   templateOptions: {
+      //     label: 'NCCN Guideline',
+      //     options: ([{ value: '', label: 'Please select an NCCN Guideline' }].concat(_.map(nccnGuidelines, function(guideline) {
+      //       return { value: guideline, label: guideline};
+      //     }))),
+      //     valueProp: 'value',
+      //     labelProp: 'label',
+      //     helpText: 'If applicable, please provide cancer (e.g., Breast Cancer) and version (e.g., 5.2016) for the appropriate <a href="http://www.nccn.org/professionals/physician_gls/default.aspx#site" target="_blank">NCCN guideline</a>.'
+      //   }
+      // },
       {
         key: 'nccn_guideline_version',
         type: 'horizontalInputHelp',

--- a/src/components/services/NccnGuidelineService.js
+++ b/src/components/services/NccnGuidelineService.js
@@ -1,0 +1,55 @@
+(function() {
+  'use strict';
+  angular.module('civic.services')
+    .factory('NccnGuidelinesResource', NccnGuidelinesResource)
+    .factory('NccnGuidelines', NccnGuidelinesService);
+
+  // @ngInject
+  function NccnGuidelinesResource($resource) {
+    return $resource('/api/nccn_guidelines',
+      {},
+      {
+        contains: {
+          method: 'GET',
+          url: '/api/nccn_guidelines?query=:query',
+          isArray: true,
+          cache: true
+        },
+        exactMatch: {
+          method: 'GET',
+          url: '/api/nccn_guidelines?query=:query&exact_match=true',
+          isArray: true,
+          cache: true
+        }
+      }
+    );
+  }
+
+  // @ngInject
+  function NccnGuidelinesService(NccnGuidelinesResource) {
+    var item = {};
+    var collection = [];
+
+    return {
+      data: {
+        item: item,
+        collection: collection
+      },
+      contains: contains,
+      exactMatch: exactMatch
+    };
+
+    function contains(query) {
+      return NccnGuidelinesResource.contains({query: query}).$promise
+        .then(function(response) {
+          return response.$promise;
+        });
+    }
+    function exactMatch(query) {
+      return NccnGuidelinesResource.exactMatch({query: query}).$promise
+        .then(function(response) {
+          return response.$promise;
+        });
+    }
+  }
+})();


### PR DESCRIPTION
NCCN Guidelines are now fetched from the server to populate a typeahead control instead of a hard-coded select dropdown. This makes it much easier to find and select the right guideline, and we don't have to keep the list updated in the client.

Closes #1255
Requires griffithlab/civic-server#568