### PR TITLE
fixes and improvements to evidence form pre-population

### DIFF
--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -8,7 +8,7 @@
   function AddAssertionConfig($stateProvider) {
     $stateProvider
       .state('add.assertion', {
-        url: '/assertion?geneId?variantId',
+        url: '/assertion?geneId?geneName?variantId?variantName?variantOrigin?diseaseName?evidenceType?evidenceDirection?clinicalSignificance',
         templateUrl: 'app/views/add/assertion/addAssertion.tpl.html',
         resolve: {
           Assertions: 'Assertions',
@@ -317,7 +317,7 @@
         controller: /* @ngInject */ function($scope, $stateParams, ConfigService, _) {
           if($stateParams.evidenceType) {
             var et = $stateParams.evidenceType;
-            var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_type);
+            var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_type.assertion);
             if(_.includes(permitted, et)) {
               $scope.model.evidence_type = $stateParams.evidenceType;
               $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[et];

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -442,8 +442,10 @@
                   $scope.model.disease = response[0];
                   $scope.to.data.doid = response[0].doid;
                 } else {
-                  // disease not found, toggle noDoid checkbox
-                  _.find($scope.fields, { key: 'noDoid'}).value(true);
+                  // disease not found, toggle noDoid checkbox & popupulate disease_name
+                  $scope.model.noDoid = true;
+                  // and populate disease_name
+                  $scope.model.disease_name = $stateParams.diseaseName;
                 }
               });
           }

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -487,7 +487,7 @@
         controller: /* @ngInject */ function($scope, $stateParams, ConfigService, _) {
           if($stateParams.evidenceType) {
             var et = $stateParams.evidenceType;
-            var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_type);
+            var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_type.evidence_item);
             if(_.includes(permitted, et)) {
               $scope.model.evidence_type = $stateParams.evidenceType;
               $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[et];

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -437,8 +437,14 @@
           if($stateParams.diseaseName) {
             Diseases.exactMatch($stateParams.diseaseName)
               .then(function(response) {
-                $scope.model.disease = response[0];
-                $scope.to.data.doid = response[0].doid;
+                if(response[0]) {
+                  // disease found, set model.disease
+                  $scope.model.disease = response[0];
+                  $scope.to.data.doid = response[0].doid;
+                } else {
+                  // disease not found, toggle noDoid checkbox
+                  _.find($scope.fields, { key: 'noDoid'}).value(true);
+                }
               });
           }
         },


### PR DESCRIPTION
This PR fixes Evidence Type pre-population, which was throwing an error, and improves disease name pre-population by activating the manual Disease Name field if no disease name is found. Previously, the field would just remain blank if no disease was found.

Waiting on a fix for #1299 before merging.

Closes #1290.

Note: To get this PR to work w/o fixing #1299, just remove `&exact_match=true` from the `url:` string in the `exactMatch` function defined early in `DiseasesService.js`