### PR TITLE
entity talk tabs no longer include entity name, just 'Revisions', 'Comments', 'Log'

### DIFF
--- a/src/app/views/events/assertions/talk/AssertionsTalkController.js
+++ b/src/app/views/events/assertions/talk/AssertionsTalkController.js
@@ -65,17 +65,17 @@
 
       angular.copy([
         {
-          heading: assertion.name + ' Revisions',
+          heading: 'Revisions',
           route: baseState + '.revisions.list',
           params: { assertionId: assertion.id }
         },
         {
-          heading: assertion.name  + ' Comments',
+          heading: 'Comments',
           route: baseState + '.comments',
           params: { assertionId: assertion.id }
         },
         {
-          heading: assertion.name + ' Log',
+          heading: 'Log',
           route: baseState + '.log',
           params: { assertionId: assertion.id }
         }
@@ -113,15 +113,6 @@
     this.AssertionRevisionsModel = AssertionRevisions;
     this.AssertionsTalkViewOptions = AssertionsTalkViewOptions;
 
-    $scope.$watch(
-      function() { return self.AssertionsTalkViewModel.data.item.name; },
-      function(newName) {
-        _.each(self.AssertionsTalkViewOptions.tabData, function(tab) {
-          var type = tab.heading.split(' ')[1];
-          tab.heading = newName + ' ' + type;
-        });
-      }
-    );
   }
 
 })();

--- a/src/app/views/events/evidence/talk/EvidenceTalkController.js
+++ b/src/app/views/events/evidence/talk/EvidenceTalkController.js
@@ -65,17 +65,17 @@
 
       angular.copy([
         {
-          heading: evidence.name + ' Revisions',
+          heading: 'Revisions',
           route: baseState + '.revisions.list',
           params: { evidenceId: evidence.id }
         },
         {
-          heading: evidence.name  + ' Comments',
+          heading: 'Comments',
           route: baseState + '.comments',
           params: { evidenceId: evidence.id }
         },
         {
-          heading: evidence.name + ' Log',
+          heading: 'Log',
           route: baseState + '.log',
           params: { evidenceId: evidence.id }
         }

--- a/src/app/views/events/genes/talk/GenesTalkController.js
+++ b/src/app/views/events/genes/talk/GenesTalkController.js
@@ -65,17 +65,17 @@
 
       angular.copy([
         {
-          heading: gene.name + ' Revisions',
+          heading: 'Revisions',
           route: baseState + '.revisions.list',
           params: { geneId: gene.id }
         },
         {
-          heading: gene.name  + ' Comments',
+          heading: 'Comments',
           route: baseState + '.comments',
           params: { geneId: gene.id }
         },
         {
-          heading: gene.name + ' Log',
+          heading: 'Log',
           route: baseState + '.log',
           params: { geneId: gene.id }
         }
@@ -112,16 +112,6 @@
     this.GenesTalkViewModel = Genes; // we're re-using the Genes model here but could in the future have a GenesTalk model if warranted
     this.GeneRevisionsModel = GeneRevisions;
     this.GenesTalkViewOptions = GenesTalkViewOptions;
-
-    $scope.$watch(
-      function() { return self.GenesTalkViewModel.data.item.name; },
-      function(newName) {
-        _.each(self.GenesTalkViewOptions.tabData, function(tab) {
-          var type = tab.heading.split(' ')[1];
-          tab.heading = newName + ' ' + type;
-        });
-      }
-    );
   }
 
 })();

--- a/src/app/views/events/variantGroups/talk/VariantGroupsTalkController.js
+++ b/src/app/views/events/variantGroups/talk/VariantGroupsTalkController.js
@@ -65,17 +65,17 @@
 
       angular.copy([
         {
-          heading: variantGroup.name + ' Revisions',
+          heading: 'Revisions',
           route: this.state.baseState + '.revisions.list',
           params: $stateParams
         },
         {
-          heading: variantGroup.name  + ' Comments',
+          heading: 'Comments',
           route: this.state.baseState + '.comments',
           params: $stateParams
         },
         {
-          heading: variantGroup.name + ' Log',
+          heading: 'Log',
           route: this.state.baseState + '.log',
           params: $stateParams
         }
@@ -113,15 +113,6 @@
     this.VariantGroupRevisionsModel = VariantGroupRevisions;
     this.VariantGroupsTalkViewOptions = VariantGroupsTalkViewOptions;
 
-    $scope.$watch(
-      function() { return self.VariantGroupsTalkViewModel.data.item.name; },
-      function(newName) {
-        _.each(self.VariantGroupsTalkViewOptions.tabData, function(tab) {
-          var type = tab.heading.split(' ')[1];
-          tab.heading = newName + ' ' + type;
-        });
-      }
-    );
   }
 
 })();

--- a/src/app/views/events/variants/talk/VariantsTalkController.js
+++ b/src/app/views/events/variants/talk/VariantsTalkController.js
@@ -65,17 +65,17 @@
 
       angular.copy([
         {
-          heading: variant.name + ' Revisions',
+          heading: 'Revisions',
           route: this.state.baseState + '.revisions.list',
           params: {  variantId: variant.id }
         },
         {
-          heading: variant.name  + ' Comments',
+          heading: 'Comments',
           route: this.state.baseState + '.comments',
           params: { variantId: variant.id }
         },
         {
-          heading: variant.name + ' Log',
+          heading: 'Log',
           route: this.state.baseState + '.log',
           params: {  variantId: variant.id }
         },
@@ -113,15 +113,5 @@
     this.VariantsTalkViewModel = Variants; // we're re-using the Variants model here but could in the future have a VariantsTalk model if warranted
     this.VariantRevisionsModel = VariantRevisions;
     this.VariantsTalkViewOptions = VariantsTalkViewOptions;
-
-    $scope.$watch(
-      function() { return self.VariantsTalkViewModel.data.item.name; },
-      function(newName) {
-        _.each(self.VariantsTalkViewOptions.tabData, function(tab) {
-          var type = tab.heading.split(' ')[1];
-          tab.heading = newName + ' ' + type;
-        });
-      }
-    );
   }
 })();


### PR DESCRIPTION
Variant names with spaces were causing display issues on the entity talk tabs, repeating the variant name and dropping the tab type. I decided to just drop the entity name from the tabs, as in some cases lengthy variant names were creating very wide tabs that look odd.

Closes #853. 