### PR TITLE
gene field gene name prepopulation now uses exact match

### DIFF
--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -119,7 +119,7 @@
           }
           // if gene name provided, get id, entrez_id
           if($stateParams.geneName){
-            Genes.beginsWith($stateParams.geneName)
+            Genes.exactMatch($stateParams.geneName)
               .then(function(response) {
                 // set field to first item on typeahead suggest
                 $scope.model.gene = response[0];

--- a/src/components/directives/headerSearch.tpl.html
+++ b/src/components/directives/headerSearch.tpl.html
@@ -31,13 +31,16 @@
           </a>
           <ul class="dropdown-menu" role="menu" uib-dropdown-menu aria-labelledby="add-dropdown">
             <li role="menuitem">
-              <a ui-sref="add.evidence.basic">Add Evidence Item</a>
+              <a ui-sref="add.evidence.basic">Evidence Item</a>
             </li>
             <li role="menuitem">
-              <a ui-sref="add.assertion">Add Assertion</a>
+              <a ui-sref="add.assertion">Assertion</a>
             </li>
             <li role="menuitem">
-              <a ui-sref="suggest.source">Add Source Suggestion</a>
+              <a ui-sref="suggest.source">Source Suggestion</a>
+            </li>
+            <li role="menuitem">
+              <a ui-sref="add.variantGroup">Variant Group</a>
             </li>
           </ul>
         </span>

--- a/src/components/services/GenesService.js
+++ b/src/components/services/GenesService.js
@@ -73,7 +73,12 @@
         isArray: true,
         cache: cache
       },
-
+      exactMatch: {
+        method: 'GET',
+        url: '/api/genes?name=:name&exact_match=true&detailed=false',
+        isArray: true,
+        cache: cache
+      },
       // Gene Additional Info
       getMyGeneInfo: {
         url: '/api/genes/:geneId/mygene_info_proxy',
@@ -280,7 +285,9 @@
       deleteComment: deleteComment,
 
       // Misc
-      beginsWith: beginsWith
+      beginsWith: beginsWith,
+      exactMatch: exactMatch
+
     };
 
     function initBase(geneId) {
@@ -383,6 +390,14 @@
         });
     }
 
+    function exactMatch(name) {
+      return GenesResource.exactMatch({
+        name: name
+      }).$promise
+        .then(function(response) {
+          return response.$promise;
+        });
+    }
     // Gene Additional Data
     function getMyGeneInfo(geneId) {
       return GenesResource.getMyGeneInfo({


### PR DESCRIPTION
Gene field controller now uses exactMatch function to populate field when URL contains geneName param, providing more consistent name lookups for genes. Also discovered the homepage Add menu hadn't been updated to include Variant Group.

Closes #887, minor update to complete #1242 