### PR TITLE
Update activtity feed to display event's stored user role, not current role of the user

### DIFF
--- a/src/app/views/activity/directives/activityGrid.js
+++ b/src/app/views/activity/directives/activityGrid.js
@@ -82,7 +82,7 @@
           }
         },
         { name: 'role',
-          field: 'user.role',
+          field: 'user_role',
           displayName: 'Role',
           enableFiltering: true,
           allowCellFocus: false,


### PR DESCRIPTION
Requires https://github.com/griffithlab/civic-server/pull/591

Closes #1245 