### PR TITLE
browse table variant group links now specify the proper gene id

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -907,7 +907,7 @@
         } else if (ctrl.mode === 'variant_groups') {
           state = 'events.genes.summary.variantGroups.summary';
           params = {
-            geneId: row.entity.gene_ids[0],
+            geneId: row.entity.gene_ids.split(', ')[0],
             variantGroupId: row.entity.id,
             '#': 'variant-group'
           };


### PR DESCRIPTION
The browse table's logic for creating variant group links was treating the variant groups' multiple gene ids as an array, but the server provides those as a string; this update splits the string into an array and uses the first gene id in the list to construct the link.