### PR TITLE
variant menu tag statuses now refreshed properly after variant revision submitted

### DIFF
--- a/src/components/services/VariantRevisionsService.js
+++ b/src/components/services/VariantRevisionsService.js
@@ -226,7 +226,7 @@
           cache.remove('/api/variants/' + reqObj.id + '/suggested_changes/');
 
           // flush variants status and refresh (for variant menu)
-          cache.remove('/api/genes/' + response.gene_id + '/variants_status');
+          cache.remove('/api/genes/' + reqObj.gene_id + '/variants_status');
           Genes.getVariantsStatus(reqObj.gene_id);
 
           // flush subscriptions and refresh


### PR DESCRIPTION
Badly formatted cache flush for the variant statuses call was preventing those indicators from updating.

Fixes #1362.