### PR TITLE
other aliases in mygeneinfo popup now shown as a comma delimited list

### DIFF
--- a/src/app/views/events/genes/summary/myGeneInfoDialog.tpl.html
+++ b/src/app/views/events/genes/summary/myGeneInfoDialog.tpl.html
@@ -16,7 +16,7 @@
     <div class="col-xs-12">
       <p>
         <strong>Other Aliases:</strong><br/>
-        <span ng-bind="geneInfo.alias"></span>
+        <span ng-bind="geneInfo.alias | arrayToList"></span>
       </p>
     </div>
   </div>


### PR DESCRIPTION
... instead of in javascript array notation.