### PR TITLE
improves the display of multi-organization features in several components

### DIFF
--- a/src/app/views/users/common/userSummary.tpl.html
+++ b/src/app/views/users/common/userSummary.tpl.html
@@ -32,7 +32,9 @@
               </tr>
               <tr>
                 <td class="key">
-                  Organization<span ng-if="user.organizations.length > 1">s</span>:
+                  <span ng-if="user.organizations.length > 1 && user.most_recent_organization != undefined">
+                  <i class="glyphicon glyphicon-info-sign" style="color: #ffdd22"
+                    uib-tooltip="Curators may choose their active organization when performing moderation actions, if they are members of more than one organization."></i>&nbsp;</span>Organization<span ng-if="user.organizations.length > 1">s</span>:
                 </td>
                 <td class="value">
                   <span ng-switch="user.organizations.length > 0">
@@ -43,7 +45,9 @@
                           <span uib-tooltip="at {{org.parent.name}}"
                             tooltip-append-to-body="true"
                             tooltip-enable="org.parent.name != undefined">
-                            <organization-block organization="org"></organization-block>
+                            <organization-block organization="org"
+                              highlight="org.id === user.most_recent_organization.id">
+                            </organization-block>
                           </span>
                         </div>
                       </span>
@@ -52,19 +56,6 @@
                     <span ng-switch-when="false" >
                       --
                     </span>
-                  </span>
-                </td>
-              </tr>
-              <tr ng-if="user.most_recent_organization.name">
-                <td class="key">
-                  <i class="glyphicon glyphicon-info-sign" style="color: #ffdd22"
-                  uib-tooltip="Curators may choose their active org when performing moderation actions, if they are members of more than one org."></i> Most Recent Org:
-                </td>
-                <td class="value" style="padding-bottom: 4px;">
-                  <span uib-tooltip="at {{user.most_recent_organization.parent.name}}"
-                    tooltip-append-to-body="true"
-                    tooltip-enable="user.most_recent_organization.parent.name != undefined">
-                    <organization-block organization="user.most_recent_organization"></organization-block>
                   </span>
                 </td>
               </tr>

--- a/src/components/directives/organizationBlock.js
+++ b/src/components/directives/organizationBlock.js
@@ -4,13 +4,13 @@
   angular.module('civic.common')
     .directive('organizationBlock', organizationBlockDirective);
 
-
   // @ngInject
   function organizationBlockDirective() {
     return /* @ngInject */ {
       restrict: 'E',
       scope: {
-        organization: '='
+        organization: '=',
+        highlight: '=?'
       },
       templateUrl: 'components/directives/organizationBlock.tpl.html'
     };

--- a/src/components/directives/organizationBlock.less
+++ b/src/components/directives/organizationBlock.less
@@ -17,6 +17,13 @@
     position: relative;
     line-height: 20px;
 
+    &.highlight {
+      margin-top: -1px;
+      padding-right: 9px;
+      padding-left: 1px;
+      border: 1px solid #FFDD22;
+    }
+
     .avatar {
       width: 14px;
       height: 14px;

--- a/src/components/directives/organizationBlock.tpl.html
+++ b/src/components/directives/organizationBlock.tpl.html
@@ -2,13 +2,13 @@
     <button
       type="button"
       class="btn btn-xs btn-organization"
+      ng-class="{'highlight': highlight == true}"
       ui-sref="organizations.summary({organizationId: organization.id})">
-          <span class="avatar">
-            <img ng-src="{{organization.profile_image.x14}}" width="14" height="14"/>
-          </span>
-          <span class="organization-name">
-            {{organization.name}}
-          </span>
-      </div>
+      <span class="avatar">
+        <img ng-src="{{organization.profile_image.x14}}" width="14" height="14"/>
+      </span>
+      <span class="organization-name">
+        {{organization.name}}
+      </span>
     </button>
 </span>

--- a/src/components/directives/userCard.tpl.html
+++ b/src/components/directives/userCard.tpl.html
@@ -59,8 +59,8 @@
                   <organization-block organization="vm.user.most_recent_organization"></organization-block>
                 </span>
               </span>
-              <span ng-switch="false" >
-               --
+              <span ng-switch-when="false">
+                <i class="text-muted">No organization specified.</i>
               </span>
             </span>
           </li>

--- a/src/components/directives/userCard.tpl.html
+++ b/src/components/directives/userCard.tpl.html
@@ -50,12 +50,18 @@
               uib-tooltip="{{vm.multiple_orgs_tooltip}}">
             </i>
           </li>
-          <li class="attr-value" >
-            <a ui-sref="organizations.summary({organizationId: vm.user.most_recent_organization.id})">
-              {{vm.user.most_recent_organization.name | ifEmpty: '--'}}
-            </a>
-            <span ng-if="vm.user.most_recent_organization.parent.name.length > 0">
-              <span class="small"><em>(at {{vm.user.most_recent_organization.parent.name}})</em></span>
+          <li class="attr-value">
+            <span ng-switch="vm.user.organizations.length > 0">
+              <span ng-switch-when="true">
+                <span uib-tooltip="at {{vm.user.most_recent_organization.parent.name}}"
+                  tooltip-append-to-body="true"
+                  tooltip-enable="vm.user.most_recent_organization.parent.name != undefined">
+                  <organization-block organization="vm.user.most_recent_organization"></organization-block>
+                </span>
+              </span>
+              <span ng-switch="false" >
+               --
+              </span>
             </span>
           </li>
           <li class="attr-key" >


### PR DESCRIPTION
Updated the way we display multiple organizations on user profile and a couple other places.

Organizations on user summaries looks like this now:
<img width="838" alt="Screenshot 2020-06-04 18 17 32" src="https://user-images.githubusercontent.com/132909/83819670-153c5b80-a690-11ea-9d35-6a32bf60465b.png">
