### PR TITLE
updated Users service so query function applies multi-org logic

### DIFF
--- a/src/app/views/users/common/userSummary.tpl.html
+++ b/src/app/views/users/common/userSummary.tpl.html
@@ -46,7 +46,7 @@
                             tooltip-append-to-body="true"
                             tooltip-enable="org.parent.name != undefined">
                             <organization-block organization="org"
-                              highlight="org.id === user.most_recent_organization.id">
+                              highlight="org.id === user.most_recent_organization.id && user.organizations.length > 1">
                             </organization-block>
                           </span>
                         </div>

--- a/src/components/services/UsersService.js
+++ b/src/components/services/UsersService.js
@@ -24,9 +24,6 @@
           method: 'GET',
           isArray: false,
           cache: false,
-          interceptor: {
-            response: UserOrgsInterceptor
-          }
         },
         query: {
           method: 'GET',
@@ -71,13 +68,18 @@
     function get(userId) {
       return UsersResource.get({userId: userId}).$promise
         .then(function(response) {
+          // use orgs interceptor to apply most recent org logic
+          var mock = {};
+          mock.data = response;
+          response = UserOrgsInterceptor(mock);
           angular.copy(response, item);
-          return $q.when(response); // kludge to handle UserOrgsInterceptor returning $promise-less response
+          return response.$promise;
         });
     }
     function query(reqObj) {
       return UsersResource.query(reqObj).$promise
         .then(function(response) {
+          // use orgs interceptor to apply most recent org logic
           response.result = response.result.map(function(u) {
             var mock = {};
             mock.data = u;


### PR DESCRIPTION
Missed a query that required the most_recent_organization logic applied to user objects. Also fixed some display logic w/ the new organization highlights in the user summary.