### PR TITLE
added 'grid-view' flag to adv. search request made to populate organization summary 

### DIFF
--- a/src/app/views/organizations/summary/OrganizationsSummaryController.js
+++ b/src/app/views/organizations/summary/OrganizationsSummaryController.js
@@ -19,7 +19,8 @@
           'name': 'is_equal_to',
           'parameters': [$scope.organization.id]
         }
-      }]
+      }],
+      'grid-view': true
     };
 
     Search.post(query).then(


### PR DESCRIPTION
hotfix to add a flag to the adv. search query that indicates to the server that a light-weight response should be returned that only includes fields required to render an evidence-grid component.

There are a couple of other instances where this query is used, however I think those will return only relatively few evidence records.

Will depend on a server hotfix to implement the lightweight response & query flag before deploying.