### PR TITLE
Releases page now displays available summary releases in datagrids, also adds variant VCF releases

### DIFF
--- a/src/app/pages/ReleasesController.js
+++ b/src/app/pages/ReleasesController.js
@@ -9,11 +9,27 @@
     var vm = this;
     // TODO move releases init to ui-router state resolve
     Releases.initBase().then(function(releases){
+      var releaseTemplate = {
+        GeneSummaries: null,
+        VariantSummaries: null,
+        ClinicalEvidenceSummaries: null,
+        VariantGroupSummaries: null,
+        AssertionSummaries: null,
+        civic_accepted: null,
+        civic_accepted_and_submitted: null
+      };
       vm.releases = _.map(releases[0], function(release) {
-        release.fileUrls = _.map(release.files, function(filename) {
-          return filename;
+        // assign note, then for each key in releaseTemplate, attach URL from file list, if found
+        var releaseObj = {
+          note: release.note
+        };
+        _.forEach(releaseTemplate, function(value, fileType) {
+          releaseObj[fileType] = _.find(release.files, function(val) {
+            return val.includes(fileType);
+          });
         });
-        return release;
+        console.log(releaseObj);
+        return releaseObj;
       });
 
     });

--- a/src/app/pages/ReleasesController.js
+++ b/src/app/pages/ReleasesController.js
@@ -7,31 +7,113 @@
   function ReleasesController($window, Releases, _) {
     console.log('ReleasesController loaded.');
     var vm = this;
-    // TODO move releases init to ui-router state resolve
-    Releases.initBase().then(function(releases){
-      var releaseTemplate = {
-        GeneSummaries: null,
-        VariantSummaries: null,
-        ClinicalEvidenceSummaries: null,
-        VariantGroupSummaries: null,
-        AssertionSummaries: null,
-        civic_accepted: null,
-        civic_accepted_and_submitted: null
-      };
-      vm.releases = _.map(releases[0], function(release) {
-        // assign note, then for each key in releaseTemplate, attach URL from file list, if found
-        var releaseObj = {
-          note: release.note
+
+    Releases.initBase()
+      .then(function(response){
+        var releases = response[0];
+        var releaseTemplate = {
+          GeneSummaries: null,
+          VariantSummaries: null,
+          ClinicalEvidenceSummaries: null,
+          VariantGroupSummaries: null,
+          AssertionSummaries: null,
+          civic_accepted: null,
+          civic_accepted_and_submitted: null
         };
-        _.forEach(releaseTemplate, function(value, fileType) {
-          releaseObj[fileType] = _.find(release.files, function(val) {
-            return val.includes(fileType);
+
+        var gridReleases = _.map(releases, function(release) {
+          var row = { note: release.note };
+          _.forEach(releaseTemplate, function(value, fileType) {
+            var url = _.find(release.files, function(url) {
+              return url === null ? false : url.includes(fileType);
+            });
+
+            row[fileType] = _.isUndefined(url) ? null : url;
           });
+          return row;
         });
-        console.log(releaseObj);
-        return releaseObj;
+        vm.summariesReleaseGridOptions.data = gridReleases;
+        vm.variantsReleaseGridOptions.data = _.filter(gridReleases, function(row) {
+          return !_.isNull(row.civic_accepted) || !_.isNull(row.civic_accepted_and_submitted);
+        });
       });
 
-    });
+    vm.summariesReleaseGridOptions = {
+      enablePaging: true,
+      minRowsToShow: 7,
+      paginationPageSizes: [5, 10, 25, 50, 75],
+      paginationPageSize: 5,
+      enableColumnMenus: false,
+      enableSorting: false,
+      data: [],
+      columnDefs: [
+        {
+          name: 'note',
+          displayName: 'Date',
+          width: '12%'
+        },
+        {
+          name: 'GeneSummaries',
+          displayName: 'Gene Summaries',
+          cellTemplate: 'app/pages/downloadCellTemplate.tpl.html',
+          type: 'string',
+
+        },
+        {
+          name: 'VariantSummaries',
+          displayName: 'Variant Summaries',
+          cellTemplate: 'app/pages/downloadCellTemplate.tpl.html',
+          type: 'string',
+        },
+        {
+          name: 'ClinicalEvidenceSummaries',
+          displayName: 'Evidence Summaries',
+          cellTemplate: 'app/pages/downloadCellTemplate.tpl.html',
+          type: 'string',
+        },
+        {
+          name: 'VariantGroupSummaries',
+          displayName: 'Variant Group Summaries',
+          cellTemplate: 'app/pages/downloadCellTemplate.tpl.html',
+          type: 'string',
+        },
+        {
+          name: 'AssertionSummaries',
+          displayName: 'Assertion Summaries',
+          cellTemplate: 'app/pages/downloadCellTemplate.tpl.html',
+          type: 'string',
+        },
+      ]
+    };
+
+    vm.variantsReleaseGridOptions = {
+      data: [],
+      enablePaging: true,
+      minRowsToShow: 7,
+      paginationPageSizes: [5, 10, 25, 50, 75],
+      paginationPageSize: 5,
+      enableColumnMenus: false,
+      enableSorting: false,
+      columnDefs: [
+        {
+          name: 'note',
+          displayName: 'Date',
+          width: '12%'
+        },
+        {
+          name: 'civic_accepted',
+          displayName: 'Accepted Variants',
+          width: '17%',
+          cellTemplate: 'app/pages/downloadCellTemplate.tpl.html',
+          type: 'string',
+        },
+        {
+          name: 'civic_accepted_and_submitted',
+          displayName: 'Accepted & Submitted Variants',
+          cellTemplate: 'app/pages/downloadCellTemplate.tpl.html',
+          type: 'string',
+        },
+      ]
+    };
   }
 })();

--- a/src/app/pages/downloadCellTemplate.tpl.html
+++ b/src/app/pages/downloadCellTemplate.tpl.html
@@ -1,0 +1,20 @@
+<div class="ui-grid-cell-contents">
+  <span ng-switch="row.entity[col.field] !== null" >
+    <span ng-switch-when="true">
+      <a class="btn btn-xs btn-default" ng-href="row.entity[col.field]" target="_self">
+        <span class="glyphicon glyphicon-download-alt"></span>
+        <span ng-switch="row.entity[col.field].includes('Summaries')">
+          <span ng-switch-when="true" >
+            Summaries TSV
+          </span>
+          <span ng-switch-when="false" >
+            Variants VCF
+          </span>
+        </span>
+      </a>
+    </span>
+    <span ng-switch-when="false">
+      --
+    </span>
+  </span>
+</div>

--- a/src/app/pages/releases.less
+++ b/src/app/pages/releases.less
@@ -3,6 +3,39 @@
 @import 'src/app/styles/_civic-variables.less';
 
 .releasesPage {
+  @ui-grid-border-radius: @border-radius-large;
+  .ui-grid {
+    border: 1px solid #DEDEDE;
+    border-radius: @ui-grid-border-radius;
+
+    .ui-grid-viewport, .ui-grid-canvas {
+      border-bottom-right-radius: @ui-grid-border-radius;
+      border-bottom-left-radius: @ui-grid-border-radius;
+    }
+
+    .ui-grid-top-panel {
+      border-top-right-radius: @ui-grid-border-radius;
+      border-top-left-radius: @ui-grid-border-radius;
+    }
+
+    .ui-grid-cell-contents {
+      cursor: pointer
+    }
+
+
+  }
+
+  .gridContainer {
+    .clearfix();
+  }
+
+  .grid-pagination {
+    .page-info {
+      color: #999;
+      margin-top: -@contentPadding;
+    }
+  }
+
   table {
     .date {
       text-align: right;

--- a/src/app/pages/releases.tpl.html
+++ b/src/app/pages/releases.tpl.html
@@ -10,13 +10,10 @@
   </div>
   <div class="row">
     <div class="col-xs-12">
-      <div class="well small">
-        <p><strong>Disclaimer:</strong> TSV releases of CIViC data are provided at regular intervals for the convenience of those who require the use of a static file.
-          For most users, we recomend utilizing our API which is documented <a href="https://griffithlab.github.io/civic-api-docs/">here</a>.
-          Using the API will provide you with the richest metadata about CIViC entries as well as the most current versions of all evidence statements.
-          In fact, the entire CIViC web frontend runs off the exact same API that is available for public use.</p>
+      <div class="well small" style="margin-bottom: 0;">
+        <p><strong>Disclaimer:</strong> TSV and VCF releases of CIViC data are provided at regular intervals for the convenience of those who require the use of a static file. For most users, we recomend utilizing our API which is documented <a href="https://griffithlab.github.io/civic-api-docs/">here</a>. Using the API will provide you with the richest metadata about CIViC entries as well as the most current versions of all evidence statements. In fact, the entire CIViC web frontend runs off the exact same API that is available for public use.</p>
 
-        <p>These TSV files do not contain user profile data, pending or rejected evidence items, discussion and commentary, or data provenance and revision history.</p>
+        <p>These files do not contain user profile data, pending or rejected evidence items, discussion and commentary, or data provenance and revision history.</p>
 
         <p>As with all curated evidence and interpretations of CIViC, the contents of these files are made freely available, without restriction under the CC0 license (<a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Public Domain Dedication, CC0 1.0 Universal</a>). If you use CIViC content, please consider citing the <a href="http://www.nature.com/ng/journal/v49/n2/full/ng.3774.html">CIViC publication</a>. No information obtained from resources external to CIViC is redistributed by these files.</p>
 
@@ -25,66 +22,20 @@
   </div>
   <div class="row">
     <div class="col-xs-12">
-      <table class="table">
-        <tr>
-          <th class="date">
-            Date
-          </th>
-          <th>
-            Gene Summaries
-          </th>
-          <th>
-            Variant Summaries
-          </th>
-          <th>
-            Variant Group Summaries
-          </th>
-          <th>
-            Evidence Summaries
-          </th>
-          <th>
-            Assertion Summaries
-          </th>
-        </tr>
-        <tr ng-repeat="release in vm.releases">
-          <td class="date" ng-bind="release.note | capitalize">
+      <h4>CIViC Summaries</h4>
+      <div class="gridContainer" >
+        <div ui-grid="vm.summariesReleaseGridOptions"
+          ui-grid-pagination
+          ui-grid-auto-resize> </div>
+      </div>
 
-          </td>
-          <td class="link">
-            <a class="btn btn-xs btn-default" ng-href="{{release.fileUrls[0]}}" target="_self">
-              <span class="glyphicon glyphicon-download-alt"></span>
-              GeneSummaries.tsv
-            </a>
-          </td>
-          <td class="link">
-            <a class="btn btn-xs btn-default" ng-href="{{release.fileUrls[1]}}" target="_self">
-              <span class="glyphicon glyphicon-download-alt"></span>
-              VariantSummaries.tsv
-            </a>
-          </td>
-          <td class="link">
-            <a class="btn btn-xs btn-default" ng-href="{{release.fileUrls[3]}}" target="_self">
-              <span class="glyphicon glyphicon-download-alt"></span>
-              VariantGroupSummaries.tsv
-            </a>
-          </td>
+      <h4>CIViC Variants</h4>
+      <div class="gridContainer" >
+        <div ui-grid="vm.variantsReleaseGridOptions"
+          ui-grid-pagination
+          ui-grid-auto-resize> </div>
+      </div>
 
-          <td class="link">
-            <a class="btn btn-xs btn-default" ng-href="{{release.fileUrls[2]}}" target="_self">
-              <span class="glyphicon glyphicon-download-alt"></span>
-              ClinicalEvidenceSummaries.tsv
-            </a>
-          </td>
-          <td class="link">
-            <a class="btn btn-xs btn-default"
-              ng-href="{{release.fileUrls[4]}}"
-              ng-if="release.fileUrls[4] != null" target="_self">
-              <span class="glyphicon glyphicon-download-alt"></span>
-              AssertionSummaries.tsv
-            </a>
-          </td>
-        </tr>
-      </table>
     </div>
   </div>
 </div>

--- a/src/components/services/ReleasesService.js
+++ b/src/components/services/ReleasesService.js
@@ -8,22 +8,14 @@
   function ReleasesResource($resource, $cacheFactory) {
     var cache = $cacheFactory.get('$http');
 
-    //var cacheInterceptor = function(response) {
-    //  console.log(['ReleasesResource: removing', response.config.url, 'from $http cache.'].join(" "));
-    //  cache.remove(response.config.url);
-    //  return response.$promise;
-    //};
-
-    return $resource('/api/releases',
-      {
-        // Base Release Resources
-        query: {
-          method: 'GET',
-          isArray: true,
-          cache: cache
-        }
+    return $resource('/api/releases?count=999', // fetch all releases
+      {}, {
+      query: {
+        method: 'GET',
+        isArray: true,
+        cache: false
       }
-    );
+    });
   }
 
   // @ngInject


### PR DESCRIPTION
Switched to using a datagrid instead of a table to show available summary releases, and added another datagrid to show available variant VCF releases.

<img width="1170" alt="Screen Shot 2020-07-02 at 11 18 49" src="https://user-images.githubusercontent.com/132909/86385390-d0d3b980-bc55-11ea-80d9-ad20c4db39e0.png">