### PR TITLE
Variant form fields now limits results to a gene (if specified), and warns if variant name is unrecognized

### DIFF
--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -204,6 +204,8 @@
           required: true,
           editable: false,
           value: 'vm.newEvidence.variant',
+          popupTemplateUrl: '/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html',
+          templateUrl: '/components/forms/fieldTypes/variantTypeahead.tpl.html',
           minLength: 32,
           helpText: help['Variant Name'],
           formatter: 'model[options.key].name',

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -183,6 +183,8 @@
           label: 'Variant Name',
           required: true,
           value: 'vm.newEvidence.variant',
+          popupTemplateUrl: '/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html',
+          templateUrl: '/components/forms/fieldTypes/variantTypeahead.tpl.html',
           minLength: 32,
           helpText: help['Variant Name'],
           formatter: 'model[options.key].name',

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -191,8 +191,8 @@
           formatter: 'model[options.key].name',
           typeahead: 'item as item.name for item in options.data.typeaheadSearch($viewValue, model.gene.name)',
           typeaheadMinLength: 0,
-          noResults: 'to.data.noResults',
           editable: true,
+          noResults: 'to.data.noResults',
           data: {
             noResults: false,
             noResultsMessage: 'Warning: this appears to be a variant unknown to CIViC. Please ensure you wish to create a new variant before submitting.'

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -195,7 +195,7 @@
           noResults: 'to.data.noResults',
           data: {
             noResults: false,
-            noResultsMessage: 'Warning: this appears to be a variant unknown to CIViC. Please ensure you wish to create a new variant before submitting.'
+            noResultsMessage: 'WARNING: This appears to be a variant unknown to CIViC. Please ensure you wish to create a new variant before submitting.'
           }
         },
         data: {

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -166,6 +166,7 @@
       {
         key: 'variant',
         type: 'horizontalTypeaheadHelp',
+        wrapper: ['noResultsMessage'],
         className: 'input-caps',
         controller: /* @ngInject */ function($scope, $stateParams, Variants) {
           // populate field if variantId provided
@@ -189,7 +190,13 @@
           helpText: help['Variant Name'],
           formatter: 'model[options.key].name',
           typeahead: 'item as item.name for item in options.data.typeaheadSearch($viewValue, model.gene.name)',
-          editable: true
+          typeaheadMinLength: 0,
+          noResults: 'to.data.noResults',
+          editable: true,
+          data: {
+            noResults: false,
+            noResultsMessage: 'Warning: this appears to be a variant unknown to CIViC. Please ensure you wish to create a new variant before submitting.'
+          }
         },
         data: {
           typeaheadSearch: function(val, gene) {
@@ -208,7 +215,7 @@
                   };
                 });
               });
-          }
+          },
         }
       },
       {

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -188,21 +188,24 @@
           minLength: 32,
           helpText: help['Variant Name'],
           formatter: 'model[options.key].name',
-          typeahead: 'item as item.name for item in options.data.typeaheadSearch($viewValue)',
+          typeahead: 'item as item.name for item in options.data.typeaheadSearch($viewValue, model.gene.name)',
           editable: true
         },
         data: {
-          typeaheadSearch: function(val) {
+          typeaheadSearch: function(val, gene) {
             var request = {
               mode: 'variants',
               count: 50,
               page: 0,
-              'filter[variant]': val
+              'filter[variant]': val,
+              'filter[entrez_gene]': gene
             };
             return Datatables.query(request)
               .then(function(response) {
                 return _.map(_.uniq(response.result, 'variant'), function(event) {
-                  return { name: event.variant };
+                  return {
+                    name: event.variant
+                  };
                 });
               });
           }

--- a/src/app/views/add/variantGroup/addVariantGroup.js
+++ b/src/app/views/add/variantGroup/addVariantGroup.js
@@ -97,6 +97,7 @@
             templateOptions: {
               formatter: 'model[options.key].name',
               typeahead: 'item as item.name for item in options.data.typeaheadSearch($viewValue)',
+              popupTemplateUrl: '/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html',
               onSelect: 'options.data.pushNew(model, index)'
             },
             data: {

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -207,6 +207,8 @@
           helpText: help['Variant Name'],
           formatter: 'model[options.key].name',
           typeahead: 'item as item.name for item in options.data.typeaheadSearch($viewValue, model.gene.name)',
+          popupTemplateUrl: '/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html',
+          templateUrl: '/components/forms/fieldTypes/variantTypeahead.tpl.html',
           typeaheadMinLength: 0,
           selectOnBlur: true,
           data: {

--- a/src/app/views/suggest/source/SuggestSourceController.js
+++ b/src/app/views/suggest/source/SuggestSourceController.js
@@ -222,7 +222,7 @@
           noResults: 'to.data.noResults',
           data: {
             noResults: false,
-            noResultsMessage: 'Warning: this appears to be a variant unknown to CIViC. Please ensure you wish to submit a new variant.'
+            noResultsMessage: 'WARNING: This appears to be a variant unknown to CIViC. Please ensure you wish to submit a new variant.'
           }
         },
         data: {

--- a/src/app/views/suggest/source/SuggestSourceController.js
+++ b/src/app/views/suggest/source/SuggestSourceController.js
@@ -211,17 +211,25 @@
           minLength: 32,
           helpText: help['Variant Name'],
           formatter: 'model[options.key].name',
-          typeahead: 'item as item.name for item in options.data.typeaheadSearch($viewValue)',
+          popupTemplateUrl: '/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html',
+          templateUrl: '/components/forms/fieldTypes/variantTypeahead.tpl.html',
+          typeahead: 'item as item.name for item in options.data.typeaheadSearch($viewValue, model.gene.name)',
+          typeaheadMinLength: 0,
           required: false,
-          editable: true
+          editable: true,
+          data: {
+            noResults: false,
+            noResultsMessage: 'Warning: this appears to be a variant unknown to CIViC. Please ensure you wish to submit a new variant.'
+          }
         },
         data: {
-          typeaheadSearch: function(val) {
+          typeaheadSearch: function(val, gene) {
             var request = {
               mode: 'variants',
-              count: 10,
+              count: 30,
               page: 0,
-              'filter[variant]': val
+              'filter[variant]': val,
+              'filter[entrez_gene]': gene
             };
             return Datatables.query(request)
               .then(function(response) {

--- a/src/app/views/suggest/source/SuggestSourceController.js
+++ b/src/app/views/suggest/source/SuggestSourceController.js
@@ -173,6 +173,7 @@
           editable: true,
           formatter: 'model[options.key].name',
           typeahead: 'item as item.name for item in to.data.typeaheadSearch($viewValue)',
+          templateUrl: 'components/forms/fieldTypes/geneTypeahead.tpl.html',
           onSelect: 'to.data.entrez_id = $model.entrez_id',
           helpText: help['Gene Entrez Name'],
           data: {

--- a/src/app/views/suggest/source/SuggestSourceController.js
+++ b/src/app/views/suggest/source/SuggestSourceController.js
@@ -196,6 +196,7 @@
       {
         key: 'variant',
         type: 'horizontalTypeaheadHelp',
+        wrapper: ['noResultsMessage'],
         model: vm.newSuggestion.suggestion,
         className: 'input-caps',
         controller: /* @ngInject */ function($scope, $stateParams, Variants) {
@@ -217,6 +218,7 @@
           typeaheadMinLength: 0,
           required: false,
           editable: true,
+          noResults: 'to.data.noResults',
           data: {
             noResults: false,
             noResultsMessage: 'Warning: this appears to be a variant unknown to CIViC. Please ensure you wish to submit a new variant.'

--- a/src/components/directives/typeaheadWrapper.js
+++ b/src/components/directives/typeaheadWrapper.js
@@ -37,6 +37,10 @@
         if(inputFormatter !== undefined) { template+='typeahead-input-formatter="'+inputFormatter+'" '; }
         var templateUrl = _.get(scope,attrs['typeaheadTemplateUrl']);
         if(templateUrl !== undefined) { template+='typeahead-template-url="'+templateUrl+'" '; }
+
+        var popupTemplateUrl = _.get(scope,'to.popupTemplateUrl');
+        if(popupTemplateUrl !== undefined) { template+='typeahead-popup-template-url="'+popupTemplateUrl+'" '; }
+
         var selectOnBlur = _.get(scope, attrs['to.selectOnBlur']);
         if (selectOnBlur !== undefined) { template+='typeahead-select-on-blur="' + selectOnBlur + '" '; }
         template+='uib-typeahead="'+_.get(scope, attrs['typeaheadWrapper'])+'" ';

--- a/src/components/directives/typeaheadWrapper.js
+++ b/src/components/directives/typeaheadWrapper.js
@@ -12,6 +12,7 @@
       link: function(scope, elem, attrs)
       {
         var template = '<input ';
+        // basic HTML & angular attributes
         template+='type="'+attrs['type']+'" ';
         template+='placeholder="{{ to.placeholder }}"';
         if(attrs['formlyCustomValidation'] !== undefined) { template += 'formlyCustomValidation '; }
@@ -26,6 +27,7 @@
         template+='ng-model="'+attrs['ngModel']+'" ';
         template+='ng-model-options="'+attrs['ngModelOptions']+'" ';
         template+='class="'+attrs['class']+'" ';
+        // existing ng-bootstrap attributes (we just copy these from the element)
         template+='typeahead-editable="'+attrs['typeaheadEditable']+'" ';
         template+='typeahead-focus-first="'+attrs['typeaheadFocusFirst']+'" ';
         template+='typeahead-append-to-body="'+attrs['typeaheadAppendToBody']+'" ';
@@ -38,6 +40,7 @@
         var templateUrl = _.get(scope,attrs['typeaheadTemplateUrl']);
         if(templateUrl !== undefined) { template+='typeahead-template-url="'+templateUrl+'" '; }
 
+        // additional elements
         var popupTemplateUrl = _.get(scope,'to.popupTemplateUrl');
         if(popupTemplateUrl !== undefined) { template+='typeahead-popup-template-url="'+popupTemplateUrl+'" '; }
 

--- a/src/components/directives/typeaheadWrapper.js
+++ b/src/components/directives/typeaheadWrapper.js
@@ -46,6 +46,10 @@
 
         var selectOnBlur = _.get(scope, attrs['to.selectOnBlur']);
         if (selectOnBlur !== undefined) { template+='typeahead-select-on-blur="' + selectOnBlur + '" '; }
+
+        var noResults = _.get(scope,'to.noResults');
+        if(noResults !== undefined) { template+='typeahead-no-results="'+noResults+'" '; }
+
         template+='uib-typeahead="'+_.get(scope, attrs['typeaheadWrapper'])+'" ';
         template+='>';
         $compile(template)(

--- a/src/components/forms/fieldTypes/typeahead.tpl.html
+++ b/src/components/forms/fieldTypes/typeahead.tpl.html
@@ -10,5 +10,6 @@
   typeahead-select-on-blur="to.selectOnBlur"
   typeahead-input-formatter="to.inputFormatter"
   typeahead-template-url="to.templateUrl"
+  typeahead-no-results="to.noResults"
   typeahead-popup-template-url="to.popupTemplateUrl"
   typeahead-wrapper="to.typeahead">

--- a/src/components/forms/fieldTypes/typeahead.tpl.html
+++ b/src/components/forms/fieldTypes/typeahead.tpl.html
@@ -10,4 +10,5 @@
   typeahead-select-on-blur="to.selectOnBlur"
   typeahead-input-formatter="to.inputFormatter"
   typeahead-template-url="to.templateUrl"
+  typeahead-popup-template-url="to.popupTemplateUrl"
   typeahead-wrapper="to.typeahead">

--- a/src/components/forms/fieldTypes/variantTypeahead.tpl.html
+++ b/src/components/forms/fieldTypes/variantTypeahead.tpl.html
@@ -1,0 +1,5 @@
+<a tabindex="-1">
+  <span ng-bind-html="match.label|uibTypeaheadHighlight:query">
+   VARIANT NAME
+  </span>
+</a>

--- a/src/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html
+++ b/src/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html
@@ -1,0 +1,6 @@
+<ul class="dropdown-menu" ng-show="isOpen() && !moveInProgress" ng-style="{top: position().top+'px', left: position().left+'px'}" role="listbox" aria-hidden="{{!isOpen()}}">
+  <li>Variant:</li>
+  <li class="uib-typeahead-match" ng-repeat="match in matches track by $index" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index, $event)" role="option" id="{{::match.id}}">
+    <div uib-typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
+  </li>
+</ul>

--- a/src/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html
+++ b/src/components/forms/fieldTypes/variantTypeaheadPopup.tpl.html
@@ -1,5 +1,14 @@
-<ul class="dropdown-menu" ng-show="isOpen() && !moveInProgress" ng-style="{top: position().top+'px', left: position().left+'px'}" role="listbox" aria-hidden="{{!isOpen()}}">
-  <li>Variant:</li>
+<ul class="dropdown-menu"
+  ng-show="isOpen() && !moveInProgress"
+  ng-style="{top: position().top+'px', left: position().left+'px'}"
+  role="listbox"
+  aria-hidden="{{!isOpen()}}">
+  <li class="dropdown-header" ng-show="$parent.model.gene.name">
+    Matching <strong>{{$parent.model.gene.name}}</strong> variants:
+  </li>
+  <li class="dropdown-header" ng-show="!$parent.model.gene.name">
+    Matching variants:
+  </li>
   <li class="uib-typeahead-match" ng-repeat="match in matches track by $index" ng-class="{active: isActive($index) }" ng-mouseenter="selectActive($index)" ng-click="selectMatch($index, $event)" role="option" id="{{::match.id}}">
     <div uib-typeahead-match index="$index" match="match" query="query" template-url="templateUrl"></div>
   </li>

--- a/src/components/forms/fieldWrappers/basicFieldWrappers.js
+++ b/src/components/forms/fieldWrappers/basicFieldWrappers.js
@@ -134,6 +134,14 @@
     });
 
     formlyConfigProvider.setWrapper({
+      name: 'noResultsMessage',
+      template: [
+        '<formly-transclude></formly-transclude>',
+        '<span class="small" style="color: #999;" ng-show="to.data.noResults && fc.$touched == true">{{ to.data.noResultsMessage }}</span>',
+      ].join(' ')
+    });
+
+    formlyConfigProvider.setWrapper({
       name: 'fieldMessage',
       template: [
         '<formly-transclude></formly-transclude>',


### PR DESCRIPTION
Variant fields in add and edit forms now show only the variants for the gene specified in the gene field (if entered). A new popup template displays 'Matching [gene] variants:' if the results are limited to a gene, or 'Matching variants:' if no gene limit is imposed.

Additionally, if a user enters a variant name that was not returned by the typeahead query, a message appears beneath the field: "WARNING: This appears to be a variant unknown to CIViC. Please ensure you wish to create a new variant before submitting."

I made a slight change to the behavior of the typehead: instead of waiting until the user enters at least one character before querying for the suggestion list, it immediately issues a query when the field is activated. I thought this might be useful in the case where a gene is entered. Upon entering the Variant field, the user can immediately see what variants are associated with that gene.

Closes #204; Closes #1313.

**Typeahead menu limiting results to a gene:**
<img width="690" alt="Screen Shot 2020-07-21 at 08 29 15" src="https://user-images.githubusercontent.com/132909/88061651-66fc5080-cb2d-11ea-8fcf-a78d2bd5d3f8.png">

**Unrecognized variant message:**
<img width="681" alt="Screen Shot 2020-07-21 at 08 31 06" src="https://user-images.githubusercontent.com/132909/88061604-55b34400-cb2d-11ea-80c4-8b9e1e17917a.png">
