### PR TITLE
evidence & assertion adv search form org dropdowns now include parent orgs

### DIFF
--- a/src/app/views/search/config/AssertionFieldConfig.js
+++ b/src/app/views/search/config/AssertionFieldConfig.js
@@ -14,7 +14,11 @@
               .value();
 
           var organizationOptions = _.chain(organizations)
-              .map(function(org) { return { value: org.name, name: org.name }; })
+              .map(function(org) {
+                var orgName = org.name +
+                    (_.isUndefined(org.parent.name) ? '' : ' at ' + org.parent.name);
+                return { value: org.name, name: orgName };
+              })
               .sortBy('name')
               .unshift({value: null, name:'Please choose an Organization'})
               .value();

--- a/src/app/views/search/config/EvidenceItemFieldConfig.js
+++ b/src/app/views/search/config/EvidenceItemFieldConfig.js
@@ -6,7 +6,11 @@
         getFields: function(organizations) {
 
           var organizationOptions = _.chain(organizations)
-              .map(function(org) { return { value: org.name, name: org.name }; })
+              .map(function(org) {
+                var orgName = org.name +
+                    (_.isUndefined(org.parent.name) ? '' : ' at ' + org.parent.name);
+                return { value: org.name, name: orgName };
+              })
               .sortBy('name')
               .unshift({value: null, name:'Please choose an Organization'})
               .value();


### PR DESCRIPTION
The 'Submitter Organization' org dropdown now appends ' at [parent org name]' to child organizations.