### PR TITLE
fixed leaderboard labels on community organizations page

### DIFF
--- a/src/app/views/community/organizations/organizationsMain.tpl.html
+++ b/src/app/views/community/organizations/organizationsMain.tpl.html
@@ -15,7 +15,7 @@
           <thead>
             <tr>
               <th class="user">
-                User
+                Organization
               </th>
               <th class="count">
                 Comments
@@ -42,7 +42,7 @@
           <thead>
             <tr>
               <th class="user">
-                User
+                Organization
               </th>
               <th class="count">
                 Submissions
@@ -70,7 +70,7 @@
           <thead>
             <tr>
               <th class="user">
-                User
+                Organization
               </th>
               <th class="count">
                 Revisions
@@ -97,7 +97,7 @@
           <thead>
             <tr>
               <th class="user">
-                User
+                Organization
               </th>
               <th class="count">
                 Moderations


### PR DESCRIPTION
'User' -> 'Organization' in all leaderboard table col headers.