### PR TITLE
Send gridView flag to server for UI searches

### DIFF
--- a/src/app/views/search/directives/queryBuilder.js
+++ b/src/app/views/search/directives/queryBuilder.js
@@ -58,6 +58,7 @@
       //vm.showEvidenceGrid = true;
       vm.model.entity = entity;
       vm.model.save = true;
+      vm.model.gridView = true;
       vm.formError = false;
       Search.post(vm.model)
         .then(function(response) { // success


### PR DESCRIPTION
For EIDs at least this was already supported on the backend, it will return a more minimal response for displaying the grid and is substantially faster and more memory efficient for evidence item searches. We can do similar things for other searches as necessity dictates. 