### PR TITLE
variant field typeahead suggestions now displayed in alphabetical order

### DIFF
--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -228,7 +228,8 @@
               count: 50,
               page: 0,
               'filter[variant]': val,
-              'filter[entrez_gene]': gene
+              'filter[entrez_gene]': gene,
+              'sorting[variant]': 'asc'
             };
             return Datatables.query(request)
               .then(function(response) {

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -205,7 +205,8 @@
               count: 50,
               page: 0,
               'filter[variant]': val,
-              'filter[entrez_gene]': gene
+              'filter[entrez_gene]': gene,
+              'sorting[variant]': 'asc'
             };
             return Datatables.query(request)
               .then(function(response) {

--- a/src/app/views/add/variantGroup/addVariantGroup.js
+++ b/src/app/views/add/variantGroup/addVariantGroup.js
@@ -109,7 +109,8 @@
                   mode: 'variants',
                   count: 5,
                   page: 0,
-                  'filter[variant]': val
+                  'filter[variant]': val,
+                  'sorting[variant]': 'asc'
                 };
                 return Datatables.query(request)
                   .then(function(response) {

--- a/src/app/views/events/assertions/edit/assertionEdit.js
+++ b/src/app/views/events/assertions/edit/assertionEdit.js
@@ -228,7 +228,8 @@
               count: 999,
               page: 0,
               'filter[variant]': val,
-              'filter[entrez_gene]': gene
+              'filter[entrez_gene]': gene,
+              'sorting[variant]': 'asc'
             };
             return Datatables.query(request)
               .then(function(response) {

--- a/src/app/views/suggest/source/SuggestSourceController.js
+++ b/src/app/views/suggest/source/SuggestSourceController.js
@@ -232,7 +232,8 @@
               count: 30,
               page: 0,
               'filter[variant]': val,
-              'filter[entrez_gene]': gene
+              'filter[entrez_gene]': gene,
+              'sorting[variant]': 'asc'
             };
             return Datatables.query(request)
               .then(function(response) {


### PR DESCRIPTION
Closes #1450 

We may want to tweak the sorting algorithm on the server, as it groups uppercase and lowercase results together, displaying uppercase before lower. Perhaps the sort should be case insensitive in order to interleave upper/lowercase results?

<img width="678" alt="Screen Shot 2020-08-12 at 11 10 06" src="https://user-images.githubusercontent.com/132909/90041673-3d979600-dc8f-11ea-865d-0890fc788cfb.png">
