### PR TITLE
active organization dropdowns now make the currently selected organization more obvious

### DIFF
--- a/src/app/views/add/assertion/addAssertion.tpl.html
+++ b/src/app/views/add/assertion/addAssertion.tpl.html
@@ -105,7 +105,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.assertion.organization.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                         ng-class="{'glyphicon-hide': org.id !== vm.assertion.organization.id}"></span>

--- a/src/app/views/add/evidence/addEvidenceBasic.tpl.html
+++ b/src/app/views/add/evidence/addEvidenceBasic.tpl.html
@@ -79,7 +79,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.newEvidence.organization.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                         ng-class="{'glyphicon-hide': org.id !== vm.newEvidence.organization.id}"></span>

--- a/src/app/views/add/variantGroup/addVariantGroup.tpl.html
+++ b/src/app/views/add/variantGroup/addVariantGroup.tpl.html
@@ -89,7 +89,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.variantGroup.organization.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                         ng-class="{'glyphicon-hide': org.id !== vm.variantGroup.organization.id}"></span>

--- a/src/app/views/events/assertions/edit/assertionEdit.tpl.html
+++ b/src/app/views/events/assertions/edit/assertionEdit.tpl.html
@@ -78,7 +78,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.assertionEdit.organization.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                           ng-class="{'glyphicon-hide': org.id !== vm.assertionEdit.organization.id}"></span>

--- a/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
+++ b/src/app/views/events/assertions/summary/components/assertionSummaryCmp.tpl.html
@@ -331,7 +331,8 @@
 </div>
 
 <script type="text/ng-template" id="org-menu.tpl.html">
-  <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+  <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+    ng-class="{'active': org.id == vm.actionOrg.id}">
     <a href ng-click="vm.switchOrg(org.id)">
       <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
         ng-class="{'glyphicon-hide': org.id !== vm.actionOrg.id}"></span>

--- a/src/app/views/events/common/editableField.tpl.html
+++ b/src/app/views/events/common/editableField.tpl.html
@@ -97,7 +97,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in ctrl.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in ctrl.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.actionOrg.id}">
                       <a href ng-click="ctrl.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                           ng-class="{'glyphicon-hide': org.id !== ctrl.actionOrg.id}"></span>

--- a/src/app/views/events/common/editableFieldFlag.tpl.html
+++ b/src/app/views/events/common/editableFieldFlag.tpl.html
@@ -73,7 +73,8 @@
                   </span>&nbsp;&nbsp;<span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                  <li role="menuitem" ng-repeat="org in ctrl.currentUser.organizations">
+                  <li role="menuitem" ng-repeat="org in ctrl.currentUser.organizations"
+                    ng-class="{'active': org.id == vm.actionOrg.id}">
                     <a href ng-click="switchOrgFn(org.id)">
                       <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                         ng-class="{'glyphicon-hide': org.id !== actionOrg.id}"></span>

--- a/src/app/views/events/common/entityCommentForm.tpl.html
+++ b/src/app/views/events/common/entityCommentForm.tpl.html
@@ -101,7 +101,8 @@
                       </span>&nbsp;&nbsp;<span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                      <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                      <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                        ng-class="{'active': org.id == vm.newComment.organization.id}">
                         <a href ng-click="vm.switchOrg(org.id)">
                           <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                             ng-class="{'glyphicon-hide': org.id !== vm.newComment.organization.id}"></span>

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.tpl.html
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.tpl.html
@@ -99,7 +99,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.evidenceEdit.organization.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                           ng-class="{'glyphicon-hide': org.id !== vm.evidenceEdit.organization.id}"></span>

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -275,7 +275,8 @@
 </div>
 
 <script type="text/ng-template" id="org-menu.tpl.html">
-  <li role="menuitem" ng-repeat="org in currentUser.organizations">
+  <li role="menuitem" ng-repeat="org in currentUser.organizations"
+    ng-class="{'active': org.id == actionOrg.id}">
     <a href ng-click="switchOrg(org.id)">
       <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
         ng-class="{'glyphicon-hide': org.id !== actionOrg.id}"></span>

--- a/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/evidence/talk/revisions/evidenceTalkRevisionSummary.tpl.html
@@ -210,7 +210,8 @@
     </div>
   </div>
   <script type="text/ng-template" id="org-menu.tpl.html">
-    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+      ng-class="{'active': org.id == vm.actionOrg.id}">
       <a href ng-click="vm.switchOrg(org.id)">
         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
           ng-class="{'glyphicon-hide': org.id !== vm.actionOrg.id}"></span>

--- a/src/app/views/events/genes/edit/geneEditBasic.tpl.html
+++ b/src/app/views/events/genes/edit/geneEditBasic.tpl.html
@@ -102,7 +102,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.geneEdit.organization.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                           ng-class="{'glyphicon-hide': org.id !== vm.geneEdit.organization.id}"></span>

--- a/src/app/views/events/genes/talk/revisions/geneTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/genes/talk/revisions/geneTalkRevisionSummary.tpl.html
@@ -184,7 +184,8 @@
   </div>
 
   <script type="text/ng-template" id="org-menu.tpl.html">
-    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+      ng-class="{'active': org.id == vm.actionOrg.id}">
       <a href ng-click="vm.switchOrg(org.id)">
         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
           ng-class="{'glyphicon-hide': org.id !== vm.actionOrg.id}"></span>

--- a/src/app/views/events/variantGroups/edit/variantGroupEditBasic.tpl.html
+++ b/src/app/views/events/variantGroups/edit/variantGroupEditBasic.tpl.html
@@ -92,7 +92,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.variantGroupEdit.organization.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                           ng-class="{'glyphicon-hide': org.id !== vm.variantGroupEdit.organization.id}"></span>

--- a/src/app/views/events/variantGroups/talk/revisions/variantGroupTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/variantGroups/talk/revisions/variantGroupTalkRevisionSummary.tpl.html
@@ -185,7 +185,8 @@
     </div>
   </div>
   <script type="text/ng-template" id="org-menu.tpl.html">
-    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+      ng-class="{'active': org.id == vm.actionOrg.id}">
       <a href ng-click="vm.switchOrg(org.id)">
         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
           ng-class="{'glyphicon-hide': org.id !== vm.actionOrg.id}"></span>

--- a/src/app/views/events/variants/edit/variantEditBasic.tpl.html
+++ b/src/app/views/events/variants/edit/variantEditBasic.tpl.html
@@ -99,7 +99,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                      ng-class="{'active': org.id == vm.variantEdit.organization.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                           ng-class="{'glyphicon-hide': org.id !== vm.variantEdit.organization.id}"></span>

--- a/src/app/views/events/variants/talk/revisions/variantTalkRevisionSummary.tpl.html
+++ b/src/app/views/events/variants/talk/revisions/variantTalkRevisionSummary.tpl.html
@@ -181,8 +181,10 @@
       <entity-comment-form type="revision" entity-model="vm.variantTalkModel"></entity-comment-form>
     </div>
   </div>
-  <script type="text/ng-template" id="org-menu.tpl.html">
-    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+  <script type="text/ng-template" id="org-menu.tpl.html"
+    ng-class="{'active': org.id == vm.currentUser.organizations}">
+    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+      ng-class="{'active': org.id == vm.actionOrg.id}">
       <a href ng-click="vm.switchOrg(org.id)">
         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
           ng-class="{'glyphicon-hide': org.id !== vm.actionOrg.id}"></span>

--- a/src/app/views/suggest/source/suggestSource.tpl.html
+++ b/src/app/views/suggest/source/suggestSource.tpl.html
@@ -61,7 +61,8 @@
                     </span>&nbsp;&nbsp;<span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
+                    <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                     ng-class="{'active': org.id == vm.actionOrg.id}">
                       <a href ng-click="vm.switchOrg(org.id)">
                         <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
                         ng-class="{'glyphicon-hide': org.id !== vm.actionOrg.id}"></span>
@@ -120,15 +121,3 @@
   <!-- </div> -->
   <!-- </div> -->
 </div>
-
-<script type="text/ng-template" id="org-menu.tpl.html">
-  <li role="menuitem" ng-repeat="org in vm.currentUser.organizations">
-    <a href ng-click="vm.switchOrg(org.id)">
-      <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
-        ng-class="{'glyphicon-hide': org.id !== vm.actionOrg.id}"></span>
-      <span class="avatar">
-        <img ng-src="{{org.profile_image.x14}}" width="14" height="14"/>
-      </span>&nbsp;&nbsp;{{org.name}}
-    </a>
-  </li>
-</script>


### PR DESCRIPTION
Now applies an 'active' class that highlights the entire row instead of just showing a checkmark.

Closes #1448 

<img width="374" alt="Screen Shot 2020-08-13 at 11 01 04" src="https://user-images.githubusercontent.com/132909/90158256-646bd000-dd54-11ea-9d6b-4dfe4361aede.png">
