### PR TITLE
updated summary helptext to emphasize the originality of the text

### DIFF
--- a/src/app/views/add/assertion/addAssertion.js
+++ b/src/app/views/add/assertion/addAssertion.js
@@ -736,7 +736,7 @@
           label: 'Description',
           required: true,
           minLength: 32,
-          helpText: 'A complete description of this new assertion, limited to one paragraph'
+          helpText: 'Your complete, original description of this new assertion, limited to one paragraph'
         }
       },
       {

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -306,7 +306,7 @@
         'Variant Origin' : 'Origin of variant',
         'Disease' : 'Please enter a disease name. If you are unable to locate the disease in the dropdown, please check the \'Could not find disease\' checkbox below and enter the disease in the field that appears.',
         'Disease Name' : 'Enter the name of the disease here.',
-        'Evidence Statement' : 'Description of evidence from published medical literature detailing the association of or lack of association of a variant with diagnostic, prognostic or predictive value in relation to a specific disease (and treatment for predictive evidence). Data constituting protected health information (PHI) should not be entered. Please familiarize yourself with your jurisdiction\'s definition of PHI before contributing.',
+        'Evidence Statement' : 'Your original description of evidence from published medical literature detailing the association of or lack of association of a variant with diagnostic, prognostic or predictive value in relation to a specific disease (and treatment for predictive evidence). Data constituting protected health information (PHI) should not be entered. Please familiarize yourself with your jurisdiction\'s definition of PHI before contributing.',
         'Evidence Type' : 'Type of clinical outcome associated with the evidence statement.',
         'Evidence Level' : 'Type of study performed to produce the evidence statement',
         'Evidence Direction' : 'An indicator of whether the evidence statement supports or refutes the clinical significance of an event. Evidence Type must be selected before this field is enabled.',


### PR DESCRIPTION
Prepended `Your original...` to evidence summary help text to indicate that the description needs to be their original work, so it now reads:

`Your original description of evidence from published medical literature detailing the association of or lack of association of a variant with diagnostic, prognostic or predictive value in relation to a specific disease (and treatment for predictive evidence). Data constituting protected health information (PHI) should not be entered. Please familiarize yourself with your jurisdiction\'s definition of PHI before contributing.`

I also did the same to the assertion summary help text, which now reads:

`Your complete, original description of this new assertion, limited to one paragraph`

Closes #1312 