### PR TITLE
changed HGVS labels from 'Expression(s)' to 'Description(s)', HGVS ID to MyVariant.info ID

### DIFF
--- a/src/app/views/events/variants/edit/variantEditBasic.js
+++ b/src/app/views/events/variants/edit/variantEditBasic.js
@@ -137,7 +137,7 @@
           required: false,
           entityName: 'Expression',
           showAddButton: false,
-          helpText: 'Please specify any HGVS expressions for this variant.',
+          helpText: 'Please specify any HGVS descriptions for this variant.',
           inputOptions: {
             type: 'basicInput',
             wrapper: '',

--- a/src/app/views/events/variants/summary/myVariantInfo.tpl.html
+++ b/src/app/views/events/variants/summary/myVariantInfo.tpl.html
@@ -10,14 +10,23 @@
           <tbody class="common">
             <tr>
               <td class="key">
+                MyVariant.info ID
+              </td>
+              <td class="key">
                 ClinVar ID
               </td>
               <td class="key">
-                ClinVar Clinical Significance
+                COSMIC ID <span class="small">(v68)</span>
               </td>
             </tr>
             <tr>
               <td class="value">
+                <div class="overflow-ellipses">
+                  {{variantInfo._id| ifEmpty: '--'}}
+                </div>
+              </td>
+              <td class="value">
+
                 <span ng-switch="!!variantInfo.clinvar.variant_id">
                   <span ng-switch-when="true">
                     <a ng-href="https://www.ncbi.nlm.nih.gov/clinvar/variation/{{variantInfo.clinvar.variant_id}}/" target="_blank">{{variantInfo.clinvar.variant_id}}</a>
@@ -26,9 +35,17 @@
                     --
                   </span>
                 </span>
+
               </td>
               <td class="value">
-                {{variantInfo.clinvar.rcv[0].clinical_significance | ifEmpty: '--'}}
+                <span ng-switch="!!variantInfo.cosmic.cosmic_id">
+                  <span ng-switch-when="true">
+                    <a ng-href="http://cancer.sanger.ac.uk/cosmic/mutation/overview?id={{variantInfo.cosmic.cosmic_id_short}}" target="_blank">{{variantInfo.cosmic.cosmic_id | ifEmpty: '--'}}</a>
+                  </span>
+                  <span ng-switch-default>
+                    {{variantInfo.cosmic.cosmic_id | ifEmpty: '--'}}
+                  </span>
+                </span>
               </td>
             </tr>
           </tbody>
@@ -46,26 +63,13 @@
           <tbody class="common">
             <tr>
               <td class="key">
-                COSMIC ID <span class="small">(v68)</span>
-              </td>
-              <td class="key">
                 dbSNP RSID
               </td>
               <td class="key">
-                HGVS ID
+                ClinVar Clinical Significance
               </td>
             </tr>
             <tr>
-              <td class="value">
-                <span ng-switch="!!variantInfo.cosmic.cosmic_id">
-                  <span ng-switch-when="true">
-                    <a ng-href="http://cancer.sanger.ac.uk/cosmic/mutation/overview?id={{variantInfo.cosmic.cosmic_id_short}}" target="_blank">{{variantInfo.cosmic.cosmic_id | ifEmpty: '--'}}</a>
-                  </span>
-                  <span ng-switch-default>
-                    {{variantInfo.cosmic.cosmic_id | ifEmpty: '--'}}
-                  </span>
-                </span>
-              </td>
               <td class="value">
                 <span ng-switch="!!variantInfo.dbsnp.rsid">
                   <span ng-switch-when="true">
@@ -77,9 +81,7 @@
                 </span>
               </td>
               <td class="value">
-                <div class="overflow-ellipses">
-                  {{variantInfo._id| ifEmpty: '--'}}
-                </div>
+                {{variantInfo.clinvar.rcv[0].clinical_significance | ifEmpty: '--'}}
               </td>
             </tr>
           </tbody>

--- a/src/app/views/events/variants/summary/myVariantInfoDialog.tpl.html
+++ b/src/app/views/events/variants/summary/myVariantInfoDialog.tpl.html
@@ -15,7 +15,7 @@
           </colgroup>
           <tr>
             <td class="key">
-              HGVS ID:
+              MyVariantInfo ID:
             </td>
             <td class="value" >
               {{variantInfo._id}}

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -100,7 +100,7 @@
           </div>
           <div class="hgvs-expressions">
             <p>
-              <strong>HGVS Expression<span ng-if="variant.hgvs_expressions.length > 1">s</span>:</strong>
+              <strong>HGVS Description(s)<span ng-if="variant.hgvs_expressions.length > 1">s</span>:</strong>
               <br/>
               <span ng-switch="variant.hgvs_expressions.length > 0">
                 <span ng-switch-when="true">

--- a/src/app/views/search/config/VariantFieldConfig.js
+++ b/src/app/views/search/config/VariantFieldConfig.js
@@ -36,7 +36,7 @@
                         { value: 'ensembl_version', name: 'Ensembl Version' },
                         { value: 'evidence_item_count', name: 'Evidence Items' },
                         { value: 'gene', name: 'Gene Entrez Name' },
-                        { value: 'hgvs_expressions', name: 'HGVS Expression(s)' },
+                        { value: 'hgvs_expressions', name: 'HGVS Description(s)' },
                         { value: 'name', name: 'Name' },
                         { value: 'pipeline_type', name: 'Pipeline Type' },
                         { value: 'reference_bases', name: 'Reference Base(s)' },


### PR DESCRIPTION
Also changed the layout of the MyVariant.info box as requested, moving most of the ID fields to the top row:

<img width="468" alt="Screen Shot 2020-08-20 at 11 54 30" src="https://user-images.githubusercontent.com/132909/90802282-9f35b100-e2dc-11ea-90ee-557f1e00f9d2.png">

Closes #1298 