### PR TITLE
fixed HGVS Description label on variant summary view

### DIFF
--- a/src/app/views/events/variants/edit/variantEditBasic.js
+++ b/src/app/views/events/variants/edit/variantEditBasic.js
@@ -133,9 +133,9 @@
         key: 'hgvs_expressions',
         type: 'multiInput',
         templateOptions: {
-          label: 'HGVS Expressions',
+          label: 'HGVS Descriptions',
           required: false,
-          entityName: 'Expression',
+          entityName: 'Description',
           showAddButton: false,
           helpText: 'Please specify any HGVS descriptions for this variant.',
           inputOptions: {

--- a/src/app/views/events/variants/summary/variantSummary.tpl.html
+++ b/src/app/views/events/variants/summary/variantSummary.tpl.html
@@ -100,7 +100,7 @@
           </div>
           <div class="hgvs-expressions">
             <p>
-              <strong>HGVS Description(s)<span ng-if="variant.hgvs_expressions.length > 1">s</span>:</strong>
+              <strong>HGVS Description<span ng-if="variant.hgvs_expressions.length > 1">s</span>:</strong>
               <br/>
               <span ng-switch="variant.hgvs_expressions.length > 0">
                 <span ng-switch-when="true">


### PR DESCRIPTION
Removed unnecessary `(s)`, also updated a multi-input field I'd missed earlier.