### PR TITLE
evidence summary views now provide button to revert status to submitted

### DIFF
--- a/src/app/views/events/common/entityTabs.js
+++ b/src/app/views/events/common/entityTabs.js
@@ -167,7 +167,7 @@
       });
 
     vm.switchOrg = function(id) {
-      vm.actionOrg = _.find(vm.currentUser.organizations, { id: id });
+      vm.revertReqObj.organization = _.find(vm.currentUser.organizations, { id: id });
     };
 
     vm.toggleSubscription = function(subscription) {

--- a/src/app/views/events/common/entityTabs.js
+++ b/src/app/views/events/common/entityTabs.js
@@ -51,6 +51,7 @@
 
     vm.type = '';
     vm.name = '';
+    vm.status = '';
 
     vm.type = _.map(entityViewModel.data.item.type.replace('_', ' ').split(' '), function(word) {
       return word.toUpperCase();
@@ -69,11 +70,19 @@
 
     fetchPending();
 
+    vm.revert = function(){
+      entityViewModel.revert(entityViewModel.data.item.id);
+    };
+
     scope.$on('revisionDecision', function(){
       fetchPending();
     });
 
     vm.anchorId = _.kebabCase(vm.type);
+
+    scope.$watch('entityViewModel.data.item.status', function(status) {
+      vm.status = status;
+    });
 
     scope.$watch('entityViewModel.data.item.name', function(name) {
       vm.name = name;

--- a/src/app/views/events/common/entityTabs.js
+++ b/src/app/views/events/common/entityTabs.js
@@ -70,9 +70,6 @@
 
     fetchPending();
 
-    vm.revert = function(reqObj){
-      entityViewModel.revert(reqObj);
-    };
 
     scope.$on('revisionDecision', function(){
       fetchPending();
@@ -132,17 +129,20 @@
 
     vm.currentUser = Security.currentUser;
 
-    // revert button stuff init
+    // revert button stuff init, null values to be populated by
+    // watchCollection function below
     vm.revertReqObj = {evidenceId: null, organization: null};
     vm.showRevertBtn = false;
     vm.entityType = null;
     vm.entityStatus = null;
+    vm.revert = null;
 
     // ideally the entity status & type would be available to this controller
     // at the time of instantiation, but unfortunately the link function
     // above adds `entityViewModel` after controller instantiation. So we
     // need to create a watchCollection function that will set up the revert
-    // request object, ensure the most recent org is updated, and toggle
+    // request object, revert function, ensure the most recent org is updated,
+    // and toggle
     // the revert button in the UI
     $scope.$watchCollection(
       '[entityViewModel.data.item.status, entityViewModel.data.item.type]',
@@ -151,12 +151,18 @@
         vm.entityType = updates[1];
         if((vm.isEditor()||vm.isAdmin()) && vm.entityType == 'evidence' && vm.entityStatus !== 'submitted') {
           vm.showRevertBtn = true;
+          vm.revert = function(reqObj) {
+            $scope.entityViewModel.revert(reqObj);
+          };
+
           Security.reloadCurrentUser().then(function(u) {
             vm.currentUser = u;
             // set org to be sent with reject/accept actions
             vm.revertReqObj.evidenceId = $stateParams.evidenceId;
             vm.revertReqObj.organization = u.most_recent_organization;
           });
+        } else {
+          vm.showRevertBtn = false;
         }
       });
 

--- a/src/app/views/events/common/entityTabs.less
+++ b/src/app/views/events/common/entityTabs.less
@@ -53,14 +53,22 @@
     // applied with ng-class in entityTabs.tpl.html
     .view-pageBackground2 {
       li.active a {
-        background-color: @pageBackground2 !important;
+        background-color: @pageBackground2;
       }
     }
     .view-pageBackground {
       li.active a {
-        background-color: @pageBackground !important;
+        background-color: @pageBackground;
       }
     }
+  }
+  // awful kludge to force proper bg color on active
+  // org-select rows in the popover 'Revert' button
+  .tab-row .view-pageBackground2 .dropdown-menu li.active a {
+   background-color: #337ab7 !important;
+  }
+  .tab-row .view-pageBackground .dropdown-menu li.active a {
+    background-color: #337ab7 !important;
   }
 
   .user-info-row {

--- a/src/app/views/events/common/entityTabs.tpl.html
+++ b/src/app/views/events/common/entityTabs.tpl.html
@@ -73,17 +73,61 @@
 
 <script type="text/ng-template" id="settingsPopover.tpl.html">
   <div class="settings-content">
-    <div class="checkbox">
-      <label>
-        <input type="checkbox" ng-model="vm.hasSubscription" ng-change="vm.toggleSubscription(vm.subscription)">
-        <span uib-tooltip="If checked, you will receive notifications when users update or comment upon this {{vm.type|lowercase}}{{ vm.type !== 'EVIDENCE' ?  ' or its child entities.' : '.' }}">Receive notifications</span>
-      </label>
-    </div>
-    <div ng-if="vm.showRevertBtn">
-      <hr/>
-      <div class="button" >
-        <a ng-click="vm.revert(vm.revertReqObj)" class="btn btn-xs btn-danger btn-block">Revert to Submitted</a>
+    <div class="row" >
+      <div class="col-xs-12" >
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" ng-model="vm.hasSubscription" ng-change="vm.toggleSubscription(vm.subscription)">
+            <span uib-tooltip="If checked, you will receive notifications when users update or comment upon this {{vm.type|lowercase}}{{ vm.type !== 'EVIDENCE' ?  ' or its child entities.' : '.' }}">Receive notifications</span>
+          </label>
+        </div>
       </div>
+    </div>
+    <div class="row" ng-if="vm.showRevertBtn" style="padding-top: 1em; border-top: 1px solid grey">
+      <div class="col-xs-12" >
+        <span ng-switch="vm.currentUser.organizations.length > 1">
+          <span ng-switch-when="true">
+            <div class="btn-group pull-right org-select" uib-dropdown>
+
+              <button id="split-button"
+                type="button"
+                class="btn btn-danger"
+                ng-click="vm.revert(vm.revertReqObj)">
+                Revert to Submitted
+              </button>
+
+              <button type="button" class="btn btn-danger" uib-dropdown-toggle>
+                for
+                <span class="avatar"
+                  uib-tooltip="{{vm.revertReqObj.organization.name}}">
+                  <img ng-src="{{vm.revertReqObj.organization.profile_image.x14}}" width="14" height="14"/>
+                </span>&nbsp;&nbsp;<span class="caret"></span>
+              </button>
+              <ul uib-dropdown-menu class="dropdown-menu" role="menu">
+                <li role="menuitem" ng-repeat="org in vm.currentUser.organizations"
+                  ng-class="{'active': org.id == vm.revertReqObj.organization.id}">
+                  <a href ng-click="vm.switchOrg(org.id)">
+                    <span class="glyphicon glyphicon-ok" style="margin-left: -12px"
+                      ng-class="{'glyphicon-hide': org.id !== vm.revertReqObj.organization.id}"></span>
+                    <span class="avatar">
+                      <img ng-src="{{org.profile_image.x14}}" width="14" height="14"/>
+                    </span>&nbsp;&nbsp;{{org.name}}
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </span>
+          <span ng-switch-default>
+            <a class="btn btn-default btn-block btn-danger"
+              ng-click="vm.revert(vm.revertReqObj)">
+              Revert to Submitted
+            </a>
+          </span>
+        </span>
+      </div>
+      <!-- <div class="button" >
+           <a ng-click="vm.revert(vm.revertReqObj)" class="btn btn-xs btn-danger btn-block">Revert to Submitted</a>
+           </div> -->
     </div>
   </div>
 </script>

--- a/src/app/views/events/common/entityTabs.tpl.html
+++ b/src/app/views/events/common/entityTabs.tpl.html
@@ -79,5 +79,11 @@
         <span uib-tooltip="If checked, you will receive notifications when users update or comment upon this {{vm.type|lowercase}}{{ vm.type !== 'EVIDENCE' ?  ' or its child entities.' : '.' }}">Receive notifications</span>
       </label>
     </div>
+    <div ng-if="vm.type == 'EVIDENCE' && vm.status !== 'submitted'">
+      <hr/>
+      <div class="button" >
+        <a ng-click="vm.revert()" class="btn btn-xs btn-danger btn-block">Revert to Submitted</a>
+      </div>
+    </div>
   </div>
 </script>

--- a/src/app/views/events/common/entityTabs.tpl.html
+++ b/src/app/views/events/common/entityTabs.tpl.html
@@ -79,7 +79,7 @@
         <span uib-tooltip="If checked, you will receive notifications when users update or comment upon this {{vm.type|lowercase}}{{ vm.type !== 'EVIDENCE' ?  ' or its child entities.' : '.' }}">Receive notifications</span>
       </label>
     </div>
-    <div ng-if="vm.type == 'EVIDENCE' && vm.status !== 'submitted'">
+    <div ng-if="vm.isEditor && vm.type == 'EVIDENCE' && vm.status !== 'submitted'">
       <hr/>
       <div class="button" >
         <a ng-click="vm.revert()" class="btn btn-xs btn-danger btn-block">Revert to Submitted</a>

--- a/src/app/views/events/common/entityTabs.tpl.html
+++ b/src/app/views/events/common/entityTabs.tpl.html
@@ -79,10 +79,10 @@
         <span uib-tooltip="If checked, you will receive notifications when users update or comment upon this {{vm.type|lowercase}}{{ vm.type !== 'EVIDENCE' ?  ' or its child entities.' : '.' }}">Receive notifications</span>
       </label>
     </div>
-    <div ng-if="vm.isEditor && vm.type == 'EVIDENCE' && vm.status !== 'submitted'">
+    <div ng-if="vm.showRevertBtn">
       <hr/>
       <div class="button" >
-        <a ng-click="vm.revert()" class="btn btn-xs btn-danger btn-block">Revert to Submitted</a>
+        <a ng-click="vm.revert(vm.revertReqObj)" class="btn btn-xs btn-danger btn-block">Revert to Submitted</a>
       </div>
     </div>
   </div>

--- a/src/components/services/EvidenceService.js
+++ b/src/components/services/EvidenceService.js
@@ -15,120 +15,125 @@
     };
 
     return $resource('/api/evidence_items/:evidenceId',
-      {
-        evidenceId: '@evidenceId'
-      },
-      {
-        // Base Evidence Resources
-        query: {
-          method: 'GET',
-          isArray: true,
-          cache: cache
-        },
-        get: { // get a single evidence
-          method: 'GET',
-          isArray: false,
-          cache: cache
-        },
-        update: {
-          method: 'PATCH',
-          interceptor: {
-            response: cacheInterceptor
-          }
-        },
-        delete: {
-          method: 'DELETE',
-          interceptor: {
-            response: cacheInterceptor
-          }
-        },
-        add: {
-          method: 'POST',
-          cache: false
-        },
-        apply: {
-          method: 'PATCH',
-          cache: false
-        },
-        accept: {
-          url: '/api/evidence_items/:evidenceId/accept',
-          method: 'POST',
-          cache: false
-        },
-        reject: {
-          url: '/api/evidence_items/:evidenceId/reject',
-          method: 'POST',
-          cache: false
-        },
+                     {
+                       evidenceId: '@evidenceId'
+                     },
+                     {
+                       // Base Evidence Resources
+                       query: {
+                         method: 'GET',
+                         isArray: true,
+                         cache: cache
+                       },
+                       get: { // get a single evidence
+                         method: 'GET',
+                         isArray: false,
+                         cache: cache
+                       },
+                       update: {
+                         method: 'PATCH',
+                         interceptor: {
+                           response: cacheInterceptor
+                         }
+                       },
+                       delete: {
+                         method: 'DELETE',
+                         interceptor: {
+                           response: cacheInterceptor
+                         }
+                       },
+                       add: {
+                         method: 'POST',
+                         cache: false
+                       },
+                       apply: {
+                         method: 'PATCH',
+                         cache: false
+                       },
+                       accept: {
+                         url: '/api/evidence_items/:evidenceId/accept',
+                         method: 'POST',
+                         cache: false
+                       },
+                       revert: {
+                         url: '/api/evidence_items/:evidenceId/revert',
+                         method: 'POST',
+                         cache: false
+                       },
+                       reject: {
+                         url: '/api/evidence_items/:evidenceId/reject',
+                         method: 'POST',
+                         cache: false
+                       },
 
-        // Evidence Collections
-        queryFlags: {
-          method: 'GET',
-          url: '/api/evidence_items/:evidenceId/flags',
-          isArray: false,
-          cache: cache
-        },
-        submitFlag: {
-          method: 'POST',
-          url: '/api/evidence_items/:evidenceId/flags',
-          cache: false
-        },
-        resolveFlag: {
-          method: 'PATCH',
-          url: '/api/evidence_items/:evidenceId/flags/:flagId',
-          params: {
-            evidenceId: '@evidenceId',
-            flagId: '@flagId'
-          },
-          cache: false
-        },
+                       // Evidence Collections
+                       queryFlags: {
+                         method: 'GET',
+                         url: '/api/evidence_items/:evidenceId/flags',
+                         isArray: false,
+                         cache: cache
+                       },
+                       submitFlag: {
+                         method: 'POST',
+                         url: '/api/evidence_items/:evidenceId/flags',
+                         cache: false
+                       },
+                       resolveFlag: {
+                         method: 'PATCH',
+                         url: '/api/evidence_items/:evidenceId/flags/:flagId',
+                         params: {
+                           evidenceId: '@evidenceId',
+                           flagId: '@flagId'
+                         },
+                         cache: false
+                       },
 
-        // Evidence Comments Resources
-        queryComments: {
-          method: 'GET',
-          url: '/api/evidence_items/:evidenceId/comments',
-          isArray: true,
-          cache: cache
-        },
-        getComment: {
-          method: 'GET',
-          url: '/api/evidence_items/:evidenceId/comments/:commentId',
-          params: {
-            evidenceId: '@evidenceId',
-            commentId: '@commentId'
-          },
-          isArray: false,
-          cache: cache
-        },
+                       // Evidence Comments Resources
+                       queryComments: {
+                         method: 'GET',
+                         url: '/api/evidence_items/:evidenceId/comments',
+                         isArray: true,
+                         cache: cache
+                       },
+                       getComment: {
+                         method: 'GET',
+                         url: '/api/evidence_items/:evidenceId/comments/:commentId',
+                         params: {
+                           evidenceId: '@evidenceId',
+                           commentId: '@commentId'
+                         },
+                         isArray: false,
+                         cache: cache
+                       },
 
-        submitComment: {
-          method: 'POST',
-          url: '/api/evidence_items/:evidenceId/comments',
-          params: {
-            evidenceId: '@evidenceId'
-          },
-          cache: false
-        },
-        updateComment: {
-          method: 'PATCH',
-          url: '/api/evidence_items/:evidenceId/comments/:commentId',
-          params: {
-            evidenceId: '@evidenceId',
-            commentId: '@commentId'
-          },
-          cache: false
-        },
-        deleteComment: {
-          method: 'DELETE',
-          url: '/api/evidence_items/:evidenceId/comments/:commentId',
-          params: {
-            evidenceId: '@evidenceId',
-            commentId: '@commentId'
-          },
-          cache: false
-        }
-      }
-    );
+                       submitComment: {
+                         method: 'POST',
+                         url: '/api/evidence_items/:evidenceId/comments',
+                         params: {
+                           evidenceId: '@evidenceId'
+                         },
+                         cache: false
+                       },
+                       updateComment: {
+                         method: 'PATCH',
+                         url: '/api/evidence_items/:evidenceId/comments/:commentId',
+                         params: {
+                           evidenceId: '@evidenceId',
+                           commentId: '@commentId'
+                         },
+                         cache: false
+                       },
+                       deleteComment: {
+                         method: 'DELETE',
+                         url: '/api/evidence_items/:evidenceId/comments/:commentId',
+                         params: {
+                           evidenceId: '@evidenceId',
+                           commentId: '@commentId'
+                         },
+                         cache: false
+                       }
+                     }
+                    );
   }
 
   // @ngInject
@@ -284,8 +289,17 @@
           return $q.reject(error);
         });
     }
-    function revert(evidenceId) {
-      console.log('EvidenceService.revert(' + evidenceId + ') called');
+    function revert(reqObj) {
+      return EvidenceResource.revert(reqObj).$promis.then(
+        function(response) { // success
+          cache.remove('/api/evidence_items/' + response.id);
+          get(reqObj.evidenceId);
+          return $q.when(response);
+        },
+        function(error) { // fail
+          return $q.reject(error);
+        });
+      console.log('EvidenceService.revert(' + reqObj.evidenceId + ') called');
     }
 
     // Evidence Collections

--- a/src/components/services/EvidenceService.js
+++ b/src/components/services/EvidenceService.js
@@ -290,10 +290,22 @@
         });
     }
     function revert(reqObj) {
-      return EvidenceResource.revert(reqObj).$promis.then(
+      return EvidenceResource.revert(reqObj).$promise.then(
         function(response) { // success
+          // flush cached variant and evidence item lists
           cache.remove('/api/evidence_items/' + response.id);
-          get(reqObj.evidenceId);
+          cache.remove('/api/variants/' + response.variant_id);
+          cache.remove('/api/variants/' + response.variant_id + '/evidence_items');
+          cache.remove('/api/genes/' + response.gene_id + '/variant_groups');
+          // refresh evidence item
+          get(response.id);
+          // refresh variant
+          Variants.get(response.variant_id);
+
+          // flush gene variants and refresh (for variant menu)
+          cache.remove('/api/genes/' + response.gene_id + '/variants?count=999');
+          Genes.queryVariants(response.gene_id);
+          Genes.queryVariantGroups(response.gene_id);
           return $q.when(response);
         },
         function(error) { // fail

--- a/src/components/services/EvidenceService.js
+++ b/src/components/services/EvidenceService.js
@@ -162,6 +162,7 @@
       delete: deleteItem,
       apply: apply,
       accept: accept,
+      revert: revert,
       reject: reject,
 
       // Evidence Comments
@@ -282,6 +283,9 @@
         function(error) { // fail
           return $q.reject(error);
         });
+    }
+    function revert(evidenceId) {
+      console.log('EvidenceService.revert(' + evidenceId + ') called');
     }
 
     // Evidence Collections


### PR DESCRIPTION
The settings popover on evidence summary views now shows a 'Revert to Submitted' button to editors. Clicking will submit a revert request and update the UI to reflect the item's new status. As with the other moderation buttons, it displays a most-recent-organization icon and provides a dropdown so the user may select an alternate for the action. Closes #1036.

<img width="1137" alt="Screen Shot 2020-10-19 at 12 13 11" src="https://user-images.githubusercontent.com/132909/96489014-76f6ff80-1204-11eb-8a87-7abaef8555b9.png">