### PR TITLE
evidence grid rows and evidence cards now show flag icon if flagged

### DIFF
--- a/src/app/views/events/common/evidenceGrid.js
+++ b/src/app/views/events/common/evidenceGrid.js
@@ -147,6 +147,11 @@
             }
           }
         },
+        {
+          name: 'flag',
+          type: 'boolean',
+          visible: false,
+        },
         { name: 'id',
           headerCellTemplate: 'app/views/events/common/evidenceGridTooltipHeader.tpl.html',
           displayName: 'EID',
@@ -155,7 +160,7 @@
           enableFiltering: true,
           allowCellFocus: false,
           minWidth: 50,
-          width: '7%',
+          width: '8%',
           cellTemplate: 'app/views/events/common/evidenceGridIdCell.tpl.html'
         },
         { name: 'gene',
@@ -557,6 +562,7 @@
 
       function prepareEvidence(evidence) {
         return _.map(evidence, function(item){
+
           // convert drug array to string
           if (_.isArray(item.drugs) && item.drugs.length > 0) {
             item.druglist = _.chain(item.drugs).map('name').value().join(', ');

--- a/src/app/views/events/common/evidenceGridIdCell.tpl.html
+++ b/src/app/views/events/common/evidenceGridIdCell.tpl.html
@@ -5,7 +5,8 @@
      tooltip-append-to-body="true">
   <span class="btn-block" ng-class="{ 'statusAccepted': row.entity['status'] === 'accepted', 'statusSubmitted': row.entity['status'] === 'submitted', 'statusRejected': row.entity['status'] === 'rejected' }">
     <i class="glyphicon glyphicon-exclamation-sign pending-alert pending-changes"
-       ng-if="row.entity['open_change_count'] > 0"></i>
+      ng-if="row.entity['open_change_count'] > 0"></i>
     {{ row.entity[col.field] }}
+    <i class="glyphicon glyphicon-flag" style="color: #942830" ng-if="row.entity['flagged']"></i>
   </span>
 </div>

--- a/src/components/directives/evidenceSelectorItem.tpl.html
+++ b/src/components/directives/evidenceSelectorItem.tpl.html
@@ -4,6 +4,9 @@
       <h3>
         <a ng-href="/links/evidence/{{ctrl.item.id}}" target="_self">
           EID{{ ctrl.item.id }}
+          <span class="glyphicon glyphicon-flag"
+            style="color: #942830; font-size: 80%;"
+            ng-if="ctrl.item.flagged"></span>
         </a>
         <span ng-if="ctrl.item.gene != undefined && ctrl.item.variant != undefined">
           <a ng-href="/links/gene/{{ctrl.item.gene.id}}" target="_self">


### PR DESCRIPTION
Currently EID rows & cards don't give any indication of the flagged status of the items they represent, this PR implements a small flag icon next to the EID display in both evidence grid rows and evidence card lists (in assertion views).

Flagged EID row in the evidence grid:
<img width="536" alt="Screen Shot 2020-10-22 at 12 33 22" src="https://user-images.githubusercontent.com/132909/96909069-1dd8d700-1463-11eb-86c1-8c3d905e7011.png">

Flagged EID in the card list:
<img width="897" alt="Screen Shot 2020-10-22 at 12 31 18" src="https://user-images.githubusercontent.com/132909/96909103-28936c00-1463-11eb-81d8-98ffa09ca16f.png">
