### PR TITLE
Add AMP Category as a column to the assertion browse table

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -279,6 +279,19 @@
           cellTemplate: 'app/views/events/common/evidenceGridClinicalSignificanceCell.tpl.html'
         },
         {
+          name: 'amp_level',
+          displayName: 'AMP Cat',
+          enableFiltering: true,
+          allowCellFocus: false,
+          headerTooltip: 'Amp Category',
+          headerCellTemplate: 'app/views/events/common/evidenceGridTooltipHeader.tpl.html',
+          cellTemplate: 'app/views/events/common/genericHighlightCell.tpl.html',
+          filter: {
+            condition: uiGridConstants.filter.CONTAINS
+          },
+          width: '10%'
+        },
+        {
           name: 'evidence_item_count',
           width: '8%',
           displayName: 'Evidence',

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -279,17 +279,17 @@
           cellTemplate: 'app/views/events/common/evidenceGridClinicalSignificanceCell.tpl.html'
         },
         {
-          name: 'amp_level',
-          displayName: 'AMP Cat',
+          name: 'amp_level_short',
+          displayName: 'AMP/ASCO/CAP Category',
           enableFiltering: true,
           allowCellFocus: false,
-          headerTooltip: 'Amp Category',
+          headerTooltip: 'AMP/ASCO/CAP Category',
           headerCellTemplate: 'app/views/events/common/evidenceGridTooltipHeader.tpl.html',
-          cellTemplate: 'app/views/events/common/genericHighlightCell.tpl.html',
+          cellTemplate: 'app/views/events/common/assertionGrid/assertionGridAmpCell.tpl.html',
           filter: {
             condition: uiGridConstants.filter.CONTAINS
           },
-          width: '10%'
+          width: '3%'
         },
         {
           name: 'evidence_item_count',

--- a/src/app/views/events/common/assertionGrid/assertionGridAmpCell.tpl.html
+++ b/src/app/views/events/common/assertionGrid/assertionGridAmpCell.tpl.html
@@ -1,0 +1,9 @@
+<div class="ampCell ngCellText"
+     uib-tooltip="{{row.entity['amp_level']}}"
+     tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
+     tooltip-placement="right"
+     tooltip-append-to-body="true">
+  <div search-highlighting='col' highlight-content="COL_FIELD">
+    {{ COL_FIELD; CUSTOM_FILTERS }}
+  </div>
+</div>


### PR DESCRIPTION
This is pretty much ready to go but for some reason the browse table header doesn't render fully for me (with or without this change). @jmcmichael will test this on his end. I'm making this a draft PR for now.

This will eventually resolve https://github.com/griffithlab/civic-client/issues/1525

Requires https://github.com/griffithlab/civic-server/pull/646