### PR TITLE
revert evidence action now properly clears, refreshes stale caches

### DIFF
--- a/src/components/services/EvidenceService.js
+++ b/src/components/services/EvidenceService.js
@@ -319,7 +319,6 @@
         function(error) { // fail
           return $q.reject(error);
         });
-      console.log('EvidenceService.revert(' + reqObj.evidenceId + ') called');
     }
 
     // Evidence Collections

--- a/src/components/services/EvidenceService.js
+++ b/src/components/services/EvidenceService.js
@@ -301,6 +301,8 @@
           get(response.id);
           // refresh variant
           Variants.get(response.variant_id);
+          // refresh variant evidence
+          Variants.queryEvidence(response.variant_id);
 
           // flush gene variants and refresh (for variant menu)
           cache.remove('/api/genes/' + response.gene_id + '/variants?count=999');

--- a/src/components/services/EvidenceService.js
+++ b/src/components/services/EvidenceService.js
@@ -308,6 +308,12 @@
           cache.remove('/api/genes/' + response.gene_id + '/variants?count=999');
           Genes.queryVariants(response.gene_id);
           Genes.queryVariantGroups(response.gene_id);
+
+          // flush all associated assertions
+          _.each(response.assertions, function(assertion) {
+            cache.remove('/api/assertions/' + assertion.id);
+          });
+
           return $q.when(response);
         },
         function(error) { // fail


### PR DESCRIPTION
Evidence grids on variant and assertion summaries now show updated evidence statuses after a revert.

Closes #1518.