### PR TITLE
flag popover may now be dismissed by clicking anywhere outside its window

### DIFF
--- a/src/app/views/events/common/editableField.tpl.html
+++ b/src/app/views/events/common/editableField.tpl.html
@@ -27,11 +27,12 @@
         ng-click="ctrl.edit()">
         <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
       </a>
-      <a class="btn  btn-xs btn-flag"
+      <a class="btn btn-xs btn-flag"
         ng-class="{'flagged': ctrl.hasActiveFlag}"
         uib-tooltip="{{ctrl.hasActiveFlag ? 'This ' + (type|lowercase) + ' has been flagged' : 'Flag this ' + (type|lowercase)}}"
         tooltip-append-to-body="true"
         uib-popover-template="'flagPopover.tpl.html'"
+        popover-trigger="'outsideClick'"
         popover-title="Flag {{type}} {{name}} "
         popover-placement="{{ctrl.popoverPlacement}}">
         <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>


### PR DESCRIPTION
Previously the user was forced to re-click the Flag button to close the popover.

Closes #1512.