### PR TITLE
browse, adv. search, and evidence grids now show entity flags

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -991,12 +991,6 @@
     function updateData() {
       fetchData(ctrl.mode, ctrl.count, ctrl.page, ctrl.sorting, ctrl.filters)
         .then(function(data){
-          // REMOVE: ADD FLAGGED BOOL FOR TESTING
-          _.forEach(data.result, function(entity) {
-            entity.flagged = (Math.random() > .5) ? true : false;
-            return entity;
-          });
-
           if(ctrl.mode === 'variant_groups') {
             // add variant_count attribute
             _.forEach(data.result, function(variant_group) {

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -107,7 +107,7 @@
           visible: false
         },
         {
-          name: 'flag',
+          name: 'flagged',
           type: 'boolean',
           visible: false,
         },
@@ -320,7 +320,7 @@
           visible: false
         },
         {
-          name: 'flag',
+          name: 'flagged',
           type: 'boolean',
           visible: false,
         },
@@ -575,10 +575,15 @@
           width: '15%',
           enableFiltering: true,
           allowCellFocus: false,
-          cellTemplate: 'app/views/events/common/genericHighlightCell.tpl.html',
+          cellTemplate: 'app/views/browse/directives/browseGridVariantCell.tpl.html',
           filter: {
             condition: uiGridConstants.filter.CONTAINS
           }
+        },
+        {
+          name: 'flagged',
+          type: 'boolean',
+          visible: false,
         },
         {
           name: 'entrez_gene',
@@ -656,6 +661,11 @@
           filter: {
             condition: uiGridConstants.filter.CONTAINS
           }
+        },
+        {
+          name: 'flagged',
+          type: 'boolean',
+          visible: false,
         },
         {
           name: 'gene_aliases',
@@ -737,6 +747,11 @@
           }
         },
         {
+          name: 'flagged',
+          type: 'boolean',
+          visible: false,
+        },
+        {
           name: 'variants',
           displayName: 'Variants',
           enableFiltering: true,
@@ -796,6 +811,11 @@
               { value: '1', label: 'ASCO'}
              ]
           }
+        },
+        {
+          name: 'flagged',
+          type: 'boolean',
+          visible: false,
         },
         {
           name: 'citation_id',
@@ -970,6 +990,12 @@
     function updateData() {
       fetchData(ctrl.mode, ctrl.count, ctrl.page, ctrl.sorting, ctrl.filters)
         .then(function(data){
+          // ADD FLAGGED BOOL FOR TESTING
+          _.forEach(data.result, function(entity) {
+            entity.flagged = (Math.random() > .5) ? true : false;
+            return entity;
+          });
+
           if(ctrl.mode === 'variant_groups') {
             // add variant_count attribute
             _.forEach(data.result, function(variant_group) {

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -991,7 +991,7 @@
     function updateData() {
       fetchData(ctrl.mode, ctrl.count, ctrl.page, ctrl.sorting, ctrl.filters)
         .then(function(data){
-          // ADD FLAGGED BOOL FOR TESTING
+          // REMOVE: ADD FLAGGED BOOL FOR TESTING
           _.forEach(data.result, function(entity) {
             entity.flagged = (Math.random() > .5) ? true : false;
             return entity;

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -285,7 +285,7 @@
         },
         {
           name: 'amp_level_short',
-          displayName: 'AMP/ASCO/CAP Category',
+          displayName: 'CAT',
           enableFiltering: true,
           allowCellFocus: false,
           headerTooltip: 'AMP/ASCO/CAP Category',
@@ -294,7 +294,7 @@
           filter: {
             condition: uiGridConstants.filter.CONTAINS
           },
-          width: '3%'
+          width: '5%'
         },
         {
           name: 'evidence_item_count',
@@ -351,7 +351,7 @@
           filter: {
             condition: uiGridConstants.filter.CONTAINS
           },
-          width: '6%'
+          width: '8%'
         },
         {
           name: 'variant_name',
@@ -364,19 +364,7 @@
           filter: {
             condition: uiGridConstants.filter.CONTAINS
           },
-          width: '8%'
-        },
-        {
-          name: 'description',
-          displayName: 'Description',
-          headerTooltip: 'Description',
-          headerCellTemplate: 'app/views/events/common/evidenceGridTooltipHeader.tpl.html',
-          enableFiltering: true,
-          allowCellFocus: false,
-          cellTemplate: 'app/views/events/common/evidenceGridEvidenceCell.tpl.html',
-          filter: {
-            condition: uiGridConstants.filter.CONTAINS
-          }
+          width: '10%'
         },
         {
           name: 'disease',
@@ -401,6 +389,19 @@
           filter: {
             condition: uiGridConstants.filter.CONTAINS
           }
+        },
+        {
+          name: 'description',
+          displayName: 'DESC',
+          headerTooltip: 'Description',
+          headerCellTemplate: 'app/views/events/common/evidenceGridTooltipHeader.tpl.html',
+          enableFiltering: true,
+          allowCellFocus: false,
+          cellTemplate: 'app/views/events/common/evidenceGridEvidenceCell.tpl.html',
+          filter: {
+            condition: uiGridConstants.filter.CONTAINS
+          },
+          width: '6%'
         },
         {
           name: 'evidence_level',

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -107,6 +107,11 @@
           visible: false
         },
         {
+          name: 'flag',
+          type: 'boolean',
+          visible: false,
+        },
+        {
           name: 'id',
           displayName: 'AID',
           visible: true,
@@ -313,6 +318,11 @@
           displayName: 'ST',
           type: 'string',
           visible: false
+        },
+        {
+          name: 'flag',
+          type: 'boolean',
+          visible: false,
         },
         {
           name: 'id',

--- a/src/app/views/browse/directives/browseGridTooltipCell.tpl.html
+++ b/src/app/views/browse/directives/browseGridTooltipCell.tpl.html
@@ -1,7 +1,7 @@
-<div class="ngCellText" ng-class="col.colIndex()"
+<div class="ngCellText ui-grid-cell-contents" ng-class="col.colIndex()"
      uib-tooltip="{{row.entity[col.field]}}"
      tooltip-append-to-body="true">
-  <div search-highlighting='col' highlight-content='row.entity[col.field]'>
+  <span search-highlighting='col' highlight-content='row.entity[col.field]'>
     {{ row.entity[col.field] }}
-  </div>
+  </span>
 </div>

--- a/src/app/views/browse/directives/browseGridVariantCell.tpl.html
+++ b/src/app/views/browse/directives/browseGridVariantCell.tpl.html
@@ -1,0 +1,10 @@
+<div class="ngCellText ui-grid-cell-contents"
+  uib-tooltip="{{ COL_FIELD}}"
+  tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
+  tooltip-placement="right"
+  tooltip-append-to-body="true">
+  <span search-highlighting='col' highlight-content='COL_FIELD'>
+    {{COL_FIELD; CUSTOM_FILTERS}}
+  </span>
+  <i class="glyphicon glyphicon-flag" style="color: #942830" ng-if="row.entity['flagged']"></i>
+</div>

--- a/src/app/views/events/common/assertionGrid/assertionGrid.js
+++ b/src/app/views/events/common/assertionGrid/assertionGrid.js
@@ -67,6 +67,11 @@
           visible: false
         },
         {
+          name: 'flag',
+          type: 'boolean',
+          visible: false,
+        },
+        {
           name: 'id',
           displayName: 'AID',
           visible: true,

--- a/src/app/views/events/common/assertionGrid/assertionGridAmpCell.tpl.html
+++ b/src/app/views/events/common/assertionGrid/assertionGridAmpCell.tpl.html
@@ -1,9 +1,9 @@
-<div class="ampCell ngCellText"
+<div class="ampCell ngCellText ui-grid-cell-contents"
      uib-tooltip="{{row.entity['amp_level']}}"
      tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
      tooltip-placement="right"
      tooltip-append-to-body="true">
-  <div search-highlighting='col' highlight-content="COL_FIELD">
+  <span search-highlighting='col' highlight-content="COL_FIELD">
     {{ COL_FIELD; CUSTOM_FILTERS }}
-  </div>
+  </span>
 </div>

--- a/src/app/views/events/common/assertionGrid/assertionGridIdCell.tpl.html
+++ b/src/app/views/events/common/assertionGrid/assertionGridIdCell.tpl.html
@@ -7,5 +7,6 @@
     <i class="glyphicon glyphicon-exclamation-sign pending-alert pending-changes"
        ng-if="row.entity['open_change_count'] > 0"></i>
     {{ row.entity[col.field] }}
+    <i class="glyphicon glyphicon-flag" style="color: #942830" ng-if="row.entity['flagged']"></i>
   </span>
 </div>

--- a/src/app/views/events/common/evidenceGridDiseaseCell.tpl.html
+++ b/src/app/views/events/common/evidenceGridDiseaseCell.tpl.html
@@ -1,9 +1,9 @@
-<div class="diseaseCell ngCellText"
+<div class="diseaseCell ngCellText ui-grid-cell-contents"
      uib-tooltip="{{ COL_FIELD }}"
      tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
      tooltip-placement="right"
      tooltip-append-to-body="true">
-  <div search-highlighting='col' highlight-content="COL_FIELD">
+  <span search-highlighting='col' highlight-content="COL_FIELD">
     {{ COL_FIELD; CUSTOM_FILTERS }}
-  </div>
+  </span>
 </div>

--- a/src/app/views/events/common/evidenceGridDrugCell.tpl.html
+++ b/src/app/views/events/common/evidenceGridDrugCell.tpl.html
@@ -1,9 +1,9 @@
-<div class="ngCellText" ng-class="col.colIndex()"
+<div class="ngCellText ui-grid-cell-contents" ng-class="col.colIndex()"
      uib-tooltip="{{row.entity['drug_interaction_type'] ? row.entity[col.field] + ' (' + row.entity['drug_interaction_type'] + ')' : row.entity[col.field]  }}"
      tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
      tooltip-placement="left"
      tooltip-append-to-body="true">
-  <div search-highlighting='col' highlight-content="row.entity['drug_interaction_type'] ? row.entity[col.field] + ' (' + row.entity['drug_interaction_type'] + ')' : row.entity[col.field]">
+  <span search-highlighting='col' highlight-content="row.entity['drug_interaction_type'] ? row.entity[col.field] + ' (' + row.entity['drug_interaction_type'] + ')' : row.entity[col.field]">
     {{ row.entity['drug_interaction_type'] ? row.entity[col.field] + ' (' + row.entity['drug_interaction_type'] + ')' : row.entity[col.field] }}
-  </div>
+  </span>
 </div>

--- a/src/app/views/events/common/evidenceGridGeneCell.tpl.html
+++ b/src/app/views/events/common/evidenceGridGeneCell.tpl.html
@@ -1,9 +1,9 @@
-<div class="ngCellText"
+<div class="ngCellText ui-grid-cell-contents"
   uib-tooltip="{{ COL_FIELD}}"
   tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
   tooltip-placement="right"
   tooltip-append-to-body="true">
-  <div search-highlighting='col' highlight-content='COL_FIELD'>
+  <span search-highlighting='col' highlight-content='COL_FIELD'>
     {{COL_FIELD; CUSTOM_FILTERS}}
-  </div>
+  </span>
 </div>

--- a/src/app/views/events/common/evidenceGridVariantCell.tpl.html
+++ b/src/app/views/events/common/evidenceGridVariantCell.tpl.html
@@ -1,9 +1,9 @@
-<div class="ngCellText"
+<div class="ngCellText ui-grid-cell-contents"
      uib-tooltip="{{ COL_FIELD}}"
      tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
      tooltip-placement="right"
      tooltip-append-to-body="true">
-    <div search-highlighting='col' highlight-content='COL_FIELD'>
+    <span search-highlighting='col' highlight-content='COL_FIELD'>
         {{COL_FIELD; CUSTOM_FILTERS}}
-    </div>
+    </span>
 </div>

--- a/src/app/views/events/common/geneGrid/geneGrid.js
+++ b/src/app/views/events/common/geneGrid/geneGrid.js
@@ -70,7 +70,7 @@
           type: 'string',
           enableFiltering: true,
           allowCellFocus: false,
-          cellTemplate: 'app/views/events/common/genericHighlightCell.tpl.html',
+          cellTemplate: 'app/views/browse/directives/browseGridVariantCell.tpl.html',
           width: '10%'
         },
         { name: 'variant_list',

--- a/src/app/views/events/common/geneGrid/tooltipCell.tpl.html
+++ b/src/app/views/events/common/geneGrid/tooltipCell.tpl.html
@@ -1,7 +1,7 @@
-<div class="ngCellText" ng-class="col.colIndex()"
+<div class="ngCellText ui-grid-cell-contents" ng-class="col.colIndex()"
      uib-tooltip="{{row.entity[col.field]}}"
      tooltip-append-to-body="true">
-  <div search-highlighting='col' highlight-content='row.entity[col.field]'>
+  <span search-highlighting='col' highlight-content='row.entity[col.field]'>
     {{ row.entity[col.field] }}
-  </div>
+  </span>
 </div>

--- a/src/app/views/events/common/genericHighlightCell.tpl.html
+++ b/src/app/views/events/common/genericHighlightCell.tpl.html
@@ -1,1 +1,3 @@
-<div search-highlighting='col' highlight-content='row.entity[col.field]'></div>
+<div search-highlighting='col'
+  highlight-content='row.entity[col.field]'
+  class="ui-grid-cell-contents"></div>

--- a/src/app/views/events/variantGroups/summary/variantGrid.js
+++ b/src/app/views/events/variantGroups/summary/variantGrid.js
@@ -82,7 +82,7 @@
           enableFiltering: true,
           allowCellFocus: false,
           type: 'string',
-          cellTemplate: 'app/views/events/common/genericHighlightCell.tpl.html',
+          cellTemplate: 'app/views/browse/directives/browseGridVariantCell.tpl.html',
           width: '20%',
           filter: {
             condition: uiGridConstants.filter.CONTAINS

--- a/src/app/views/events/variantGroups/summary/variantGridDescriptionCell.tpl.html
+++ b/src/app/views/events/variantGroups/summary/variantGridDescriptionCell.tpl.html
@@ -1,4 +1,4 @@
-<div class="ngCellText" ng-class="col.colIndex()"
+<div class="ngCellText ui-grid-cell-contents" ng-class="col.colIndex()"
      uib-tooltip="{{row.entity[col.field]}}"
      tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
      tooltip-placement="top"

--- a/src/app/views/events/variantGroups/summary/variantGridTooltipCell.tpl.html
+++ b/src/app/views/events/variantGroups/summary/variantGridTooltipCell.tpl.html
@@ -1,9 +1,9 @@
-<div class="ngCellText" ng-class="col.colIndex()"
+<div class="ngCellText ui-grid-cell-contents" ng-class="col.colIndex()"
      uib-tooltip="{{row.entity[col.field]}}"
      tooltip-popup-delay="{{ctrl.tooltipPopupDelay}}"
      tooltip-placement="top"
      tooltip-append-to-body="true">
-  <div search-highlighting='col' highlight-content='row.entity[col.field]'>
+  <span search-highlighting='col' highlight-content='row.entity[col.field]'>
     {{ row.entity[col.field] }}
-  </div>
+  </span>
 </div>

--- a/src/app/views/search/directives/queryBuilder.js
+++ b/src/app/views/search/directives/queryBuilder.js
@@ -68,6 +68,12 @@
             var state = entity === 'evidence_items' ? 'search.evidence' : 'search.' + entity;
             $state.transitionTo(state, { token: response.token }, {notify: false});
           }
+          // REMOVE: ADD FLAGGED BOOL FOR TESTING
+          _.forEach(vm.searchResults, function(entity) {
+            entity.flagged = (Math.random() > .5) ? true : false;
+            return entity;
+          });
+
         },
         function(response) { // error
           angular.copy([], vm.searchResults);
@@ -85,6 +91,12 @@
             vm.model.operator = response.params.operator;
             vm.model.queries = response.params.queries;
             vm.searchResults = response.results;
+            // REMOVE: ADD FLAGGED BOOL FOR TESTING
+            _.forEach(vm.searchResults, function(entity) {
+              entity.flagged = (Math.random() > .5) ? true : false;
+              return entity;
+            });
+
             vm.showGrid = true;
           });
       } else {

--- a/src/app/views/search/directives/queryBuilder.js
+++ b/src/app/views/search/directives/queryBuilder.js
@@ -68,12 +68,6 @@
             var state = entity === 'evidence_items' ? 'search.evidence' : 'search.' + entity;
             $state.transitionTo(state, { token: response.token }, {notify: false});
           }
-          // REMOVE: ADD FLAGGED BOOL FOR TESTING
-          _.forEach(vm.searchResults, function(entity) {
-            entity.flagged = (Math.random() > .5) ? true : false;
-            return entity;
-          });
-
         },
         function(response) { // error
           angular.copy([], vm.searchResults);
@@ -91,12 +85,6 @@
             vm.model.operator = response.params.operator;
             vm.model.queries = response.params.queries;
             vm.searchResults = response.results;
-            // REMOVE: ADD FLAGGED BOOL FOR TESTING
-            _.forEach(vm.searchResults, function(entity) {
-              entity.flagged = (Math.random() > .5) ? true : false;
-              return entity;
-            });
-
             vm.showGrid = true;
           });
       } else {

--- a/src/app/views/sources/components/cellTemplateTooltip.tpl.html
+++ b/src/app/views/sources/components/cellTemplateTooltip.tpl.html
@@ -1,7 +1,7 @@
-<div class="ngCellText" ng-class="col.colIndex()"
+<div class="ngCellText ui-grid-cell-contents" ng-class="col.colIndex()"
      uib-tooltip="{{row.entity[col.field]}}"
      tooltip-append-to-body="true">
-  <div search-highlighting='col' highlight-content='row.entity[col.field]'>
+  <span search-highlighting='col' highlight-content='row.entity[col.field]'>
     {{ row.entity[col.field] }}
-  </div>
+  </span>
 </div>

--- a/src/components/directives/searchHighlighting.tpl.html
+++ b/src/components/directives/searchHighlighting.tpl.html
@@ -1,1 +1,1 @@
-<div class='ui-grid-cell-contents' ng-bind-html="content | highlightSearch:query.filters[0].term"></div>
+<span class='ui-grid-cell-contents' ng-bind-html="content | highlightSearch:query.filters[0].term"></span>


### PR DESCRIPTION
The various grids on Browse, Search and the evidence grids now show a red flag icon next to flagged entities.

Closes #1516