### PR TITLE
add evidence disease field now shows 'not found' msg if disease not in db

### DIFF
--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -464,10 +464,8 @@
                   $scope.model.disease = response[0];
                   $scope.to.data.doid = response[0].doid;
                 } else {
-                  // disease not found, toggle noDoid checkbox
-                  $scope.model.noDoid = true;
-                  // and populate disease_name
-                  $scope.model.disease_name = $stateParams.diseaseName;
+                  // disease not found, show msg to user
+                  $scope.to.data.doid = 'Suggested disease "' + $stateParams.diseaseName + '" not found.';
                 }
                 // toggle searched flag, ensuring prepopulation search is
                 // only performed once

--- a/src/app/views/suggest/source/SuggestSourceController.js
+++ b/src/app/views/suggest/source/SuggestSourceController.js
@@ -255,7 +255,7 @@
           required: false,
           editable: true,
           minLength: 32,
-          helpText: help['Disease'],
+          helpText: 'Please enter a disease name.',
           typeahead: 'item as item.name for item in to.data.typeaheadSearch($viewValue)',
           onSelect: 'to.data.doid = $model.doid',
           templateUrl: 'components/forms/fieldTypes/diseaseTypeahead.tpl.html',

--- a/src/app/views/suggest/source/SuggestSourceController.js
+++ b/src/app/views/suggest/source/SuggestSourceController.js
@@ -366,8 +366,14 @@
       if(!_.isUndefined(req.variant) && _.isObject(req.variant)) {
         reqObj.variant_name = req.variant.name;
       }
-      if(!_.isUndefined(req.disease) && _.isObject(req.disease)) {
-        reqObj.disease_name = req.disease.name;
+      if(!_.isUndefined(req.disease)) {
+        if(_.isObject(req.disease)) {
+          // disease field populated by disease obj retrieved from db
+          reqObj.disease_name = req.disease.name;
+        } else {
+          // disease field populated by string (wasn't found in db)
+          reqObj.disease_name = req.disease;
+        }
       }
       Sources.suggest(reqObj).then(
         function(response) { // success

--- a/src/app/views/suggest/source/suggestSource.tpl.html
+++ b/src/app/views/suggest/source/suggestSource.tpl.html
@@ -110,14 +110,14 @@
     </div>
   </div>
 
-  <!-- <div class="row" style="margin-top: 3em;"> -->
-  <!-- <div class="col-xs-6"> -->
-  <!-- <p>vm.newSuggestion</p> -->
-  <!-- <pre ng-bind="vm.newSuggestion|json"></pre> -->
-  <!-- </div> -->
-  <!-- <div class="col-xs-6"> -->
-  <!-- <p>Form:</p> -->
-  <!-- <pre ng-bind="vm.suggestionFields|json"></pre> -->
-  <!-- </div> -->
-  <!-- </div> -->
+  <!-- <div class="row" style="margin-top: 3em;">
+       <div class="col-xs-6">
+       <p>vm.newSuggestion</p>
+       <pre ng-bind="vm.newSuggestion|json"></pre>
+       </div>
+       <div class="col-xs-6">
+       <p>Form:</p>
+       <pre ng-bind="vm.suggestionFields|json"></pre>
+       </div>
+       </div> -->
 </div>


### PR DESCRIPTION
Add Evidence form's disease fields, instead of checking 'disease not found' and populating the free-text disease field, now shows a 'not found' message.

Closes #1534 

**Example of disease field 'not found' msg**
<img width="598" alt="Screen Shot 2020-11-19 at 11 37 56" src="https://user-images.githubusercontent.com/132909/99702837-ee19f080-2a5b-11eb-819e-c97ee0234227.png">
