### PR TITLE
variant type field's typeahead now displays root concept

### DIFF
--- a/src/app/views/events/variants/edit/variantEditBasic.js
+++ b/src/app/views/events/variants/edit/variantEditBasic.js
@@ -302,7 +302,7 @@
         type: 'multiInput',
         templateOptions: {
           label: 'Variant Type(s)',
-          helpText: 'Add one or more variant types from the <a href="http://www.sequenceontology.org/browser/" title="Opens a new tab for the Sequence Ontology Browser" target="_blank">Sequence Ontology</a> (e.g., missense, loss-of-function).',
+          helpText: 'Add one or more variant types from the <a href="http://www.sequenceontology.org/browser/" title="Opens a new tab for the Sequence Ontology Browser" target="_blank">Sequence Ontology</a> (e.g., missense, loss-of-function). Please be specific as possible, and avoid the addition of root concepts.',
           entityName: 'Type',
           showAddButton: false,
           inputOptions: {
@@ -311,11 +311,12 @@
             templateOptions: {
               formatter: 'model[options.key].display_name',
               typeahead: 'item as item.display_name for item in to.data.typeaheadSearch($viewValue)',
+              templateUrl: 'components/forms/fieldTypes/variantTypeTypeahead.tpl.html',
               editable: false,
               data: {
                 typeaheadSearch: function(val) {
                   var request = {
-                    count: 5,
+                    count: 25,
                     page: 0,
                     name: val
                   };

--- a/src/components/forms/fieldTypes/variantTypeTypeahead.tpl.html
+++ b/src/components/forms/fieldTypes/variantTypeTypeahead.tpl.html
@@ -1,0 +1,14 @@
+<a tabindex="-1">
+  <span ng-switch="match.model.so_id === match.model.root_concept.so_id">
+    <span ng-switch-when="false" >
+      <span ng-bind-html="match.label|uibTypeaheadHighlight:query">VARIANT TYPE NAME</span>
+      <span style="color: #AAA;">&nbsp;(<span ng-bind="match.model.root_concept.name"></span>)</span>
+    </span>
+    <span ng-switch-when="true" >
+      <span style="color: #999;">
+        <span ng-bind-html="match.label|uibTypeaheadHighlight:query">VARIANT TYPE NAME</span>
+      </span>
+      <span style="color: #AAA;">&nbsp;(<i>Root Concept</i>)</span>
+    </span>
+  </span>
+</a>


### PR DESCRIPTION
In addition to the type name, its root concept is appended. If the type is itself a root concept, it's displayed slightly greyed out, as curators should avoid specifying root concepts. 25 matches are displayed instead of 5.

Additionally, updated the help text to add a sentence about specificity and root concepts:

> Add one or more variant types from the Sequence Ontology (e.g., missense, loss-of-function). Please be specific as possible, and avoid the addition of root concepts.

Closes #1536, requires griffithlab/civic-server#649

<img width="674" alt="Screen Shot 2020-11-20 at 14 01 09" src="https://user-images.githubusercontent.com/132909/99845451-4b846f00-2b3a-11eb-8cfa-7202e497a0bf.png">
