### PR TITLE
Add Oncogenic Clinical Significance

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -514,6 +514,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
+              { value: 'Oncogenic', label: 'Oncogenic' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/common/evidenceGrid.js
+++ b/src/app/views/events/common/evidenceGrid.js
@@ -342,6 +342,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
+              { value: 'Oncogenic', label: 'Oncogenic'},
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/common/evidenceGridClinicalSignificanceCell.tpl.html
+++ b/src/app/views/events/common/evidenceGridClinicalSignificanceCell.tpl.html
@@ -26,6 +26,7 @@
     'glyphicon-resize-horizontal' : row.entity[col.field] === 'Unaltered Function',
     'glyphicon-exclamation-sign' : row.entity[col.field] === 'Neomorphic',
     'glyphicon-resize-full' : row.entity[col.field] === 'Dominant Negative',
+    'glyphicon-certificate': row.entity[col.field] === 'Oncogenic',
     'glyphicon-log-out' : row.entity[col.field] === 'Unknown',}">
   </span>
 </div>

--- a/src/app/views/events/common/evidenceGridPopoverKey.tpl.html
+++ b/src/app/views/events/common/evidenceGridPopoverKey.tpl.html
@@ -486,6 +486,14 @@
               </tr>
               <tr>
                 <td class="symbol clinicalCell">
+                  <span class="glyphicon glyphicon-certificate"></span>
+                </td>
+                <td class="symbol-description">
+                  Oncogenic
+                </td>
+              </tr>
+              <tr>
+                <td class="symbol clinicalCell">
                   <span class="glyphicon glyphicon-log-out"></span>
                 </td>
                 <td class="symbol-description">

--- a/src/app/views/events/common/evidenceSelector/evidenceSelector.js
+++ b/src/app/views/events/common/evidenceSelector/evidenceSelector.js
@@ -320,6 +320,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
+              { value: 'Oncogenic', name: 'Oncogenic' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]
@@ -531,6 +532,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
+              { value: 'Oncogenic', name: 'Oncogenic' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/search/config/EvidenceItemFieldConfig.js
+++ b/src/app/views/search/config/EvidenceItemFieldConfig.js
@@ -566,6 +566,7 @@
                           { value: 'Unaltered Function', name: 'Unaltered Function'},
                           { value: 'Neomorphic', name: 'Neomorphic'},
                           { value: 'Dominant Negative', name: 'Dominant Negative' },
+                          { value: 'Oncogenic', name: 'Oncogenic' },
                           { value: 'Unknown', name: 'Unknown'},
                           { value: 'N/A', name: 'N/A' }
                         ]

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -257,6 +257,7 @@
               'Unaltered Function': 'Gene product of sequence variant is unchanged',
               'Neomorphic': 'Sequence variant creates a novel function',
               'Dominant Negative': 'Seuqnce variant abolishes wild type allele function',
+              'Oncogenic': 'Sequence variant that induces or increases oncogenic cellular potential',
               'Unknown': 'Sequence variant that cannot be precisely defined the other listed categories',
             },
           },


### PR DESCRIPTION
Closes #1455 

Requires https://github.com/griffithlab/civic-server/pull/664

This PR is still a work in progress. It adds the new "Oncogenic" option to the advanced search, dropdowns, add and edit forms etc. However, we still need to implement the following constraints in the add/edit evidence form:

For Functional evidence, if a user selects Oncogenic then selecting a Disease is required. However, if they pick one of the other clinical significance values Disease must be empty (the form field should be hidden).