### PR TITLE
stats page now leaves 'N/A' formatting intact, handles empty string keys

### DIFF
--- a/src/app/pages/statistics/directives/countsByClinicalSignificance.js
+++ b/src/app/pages/statistics/directives/countsByClinicalSignificance.js
@@ -67,7 +67,7 @@
     }, function(data) {
       chart.data = _.map(data, function(key, value) {
         return {
-          'Clinical Significance': value === "n/a" ? "N/A" : _.capitalize(value),
+          'Clinical Significance': value === '' ? 'None assigned' : value,
           Count: key
         };
       });

--- a/src/app/pages/statistics/directives/countsByEvidenceDirection.js
+++ b/src/app/pages/statistics/directives/countsByEvidenceDirection.js
@@ -66,7 +66,7 @@
     }, function(data) {
       chart.data = _.map(data, function(key, value) {
         return {
-          Direction: _.capitalize(value),
+          Direction:  value === '' ? 'None assigned' : value,
           Count: key
         };
       });

--- a/src/app/pages/statistics/directives/countsByVariantOrigin.js
+++ b/src/app/pages/statistics/directives/countsByVariantOrigin.js
@@ -66,7 +66,7 @@
     }, function(data) {
       chart.data = _.map(data, function(key, value) {
         return {
-          Origin: value === "n/a" ? "N/A" : _.capitalize(value),
+          Origin: value === '' ? 'None assigned' : value,
           Count: key
         };
       });


### PR DESCRIPTION
Previously 'N/A' would be transformed to 'N/a', charts now leave it untransformed. Additionally, empty string values are shown as 'None assigned', previously a blank item would be included in the key.