### PR TITLE
browse page evidence grid EID flags no longer wrap

### DIFF
--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -338,7 +338,7 @@
             condition: uiGridConstants.filter.CONTAINS
           },
           minWidth: 75,
-          width: '5%'
+          width: '8%'
         },
         {
           name: 'gene_name',


### PR DESCRIPTION
Widened the column so the wider EIDs no longer wrap. Narrower browser widths might wrap with long IDs plus both flag and pending revision icons, not too much to do about that without making the column extremely wide. v2 icon system will help mitigate these kinds of problems!