### PR TITLE
'resolve' button no longer displayed on a flag if COI notice expired

### DIFF
--- a/src/app/views/events/common/editableFieldFlag.tpl.html
+++ b/src/app/views/events/common/editableFieldFlag.tpl.html
@@ -49,7 +49,7 @@
             </a>
           </span>
           <!-- show org-select button if user is member of > 1 orgs -->
-          <span ng-switch="ctrl.currentUser.organizations.length > 1" >
+          <span ng-switch="ctrl.currentUser.organizations.length > 1 && !ctrl.showCoiNotice" >
             <span ng-switch-when="true" >
               <div class="btn-group org-select" uib-dropdown style="float: right;">
                 <button id="split-button"


### PR DESCRIPTION
Fixed template logic to properly hide 'Resolve' button if COI notice displayed, previously the organization dropdown was showing up along with the Update COI button.