### PR TITLE
implements logic for add/edit & display of functional oncogenic evidence

### DIFF
--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -381,7 +381,7 @@
             }
           }
 
-          $scope.pubmedField = _.find($scope.fields, { key: 'pubmed_id' });
+          $scope.sourceField = _.find($scope.fields, { key: 'source.citation_id' });
 
           $scope.$watchGroup([
             'model.gene.name',

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -112,6 +112,17 @@
       return (isFunctional && !isOncogenic);
     };
 
+    var resetDiseaseFields = function(scope) {
+      var disField = _.find(scope.fields, { key: 'disease'});
+      var noDoidField = _.find(scope.fields, { key: 'noDoid'});
+      var disNameField = _.find(scope.fields, { key: 'disease_name'});
+
+      disField.value({name: ''});
+      noDoidField.value(false);
+      // disease name field may not be instantiated with a value function
+      if(disNameField.value) { disNameField.value(''); }
+    };
+
     vm.evidenceFields = [
       {
         key: 'gene',
@@ -458,6 +469,11 @@
             csField.templateOptions.data.attributeDefinition = '';
             edField.templateOptions.data.attributeDefinition = '';
 
+            // reset disease fields if switching to Functional
+            if(value === 'Functional') {
+              resetDiseaseFields(scope);
+            }
+
             // if we're switching to Predictive, seed the drugs array w/ a blank entry,
             // otherwise set to empty array
             value === 'Predictive' ? scope.model.drugs = [''] : scope.model.drugs = [];
@@ -516,6 +532,13 @@
           },
           onChange: function(value, options, scope) {
             options.templateOptions.data.updateDefinition(value, options, scope);
+
+            // if switching from Functional Oncogenic, reset disease fields
+            var etField = _.find(scope.fields, { key: 'evidence_type'});
+            if(etField.value() === 'Functional' && value !== 'Oncogenic') {
+              resetDiseaseFields(scope);
+            }
+
           }
         },
         expressionProperties: {

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -105,6 +105,13 @@
       vm.newEvidence.organization = vm.currentUser.most_recent_organization;
     });
 
+    // form helper functions
+    var hideDiseaseFields = function(model) {
+      var isFunctional = model.evidence_type === 'Functional';
+      var isOncogenic = model.clinical_significance === 'Oncogenic';
+      return (isFunctional && !isOncogenic);
+    };
+
     vm.evidenceFields = [
       {
         key: 'gene',
@@ -473,24 +480,12 @@
               });
           }
         },
-
         expressionProperties: {
           'templateOptions.disabled': 'model.noDoid === true', // deactivate if noDoid is checked
           'templateOptions.required': 'model.noDoid === false' // required only if noDoid is unchecked
         },
-        hideExpression: 'model.noDoid'
-      },
-      {
-        key: 'noDoid',
-        type: 'horizontalCheckbox',
-        templateOptions: {
-          label: 'Could not find disease.',
-          onChange: function(value, options, scope) {
-            // reset disease fields
-            scope.model.disease = { name: '' };
-            scope.model.disease_name = '';
-          }
-
+        hideExpression: function($viewValue, $modelValue, scope) {
+          return hideDiseaseFields(scope.model) || scope.model.noDoid;
         }
       },
       {
@@ -504,6 +499,22 @@
           helpText: help['Disease Name']
         },
         hideExpression: '!model.noDoid'
+      },
+      {
+        key: 'noDoid',
+        type: 'horizontalCheckbox',
+        templateOptions: {
+          label: 'Could not find disease.',
+          onChange: function(value, options, scope) {
+            // reset disease fields
+            scope.model.disease = { name: '' };
+            scope.model.disease_name = '';
+          }
+
+        },
+        hideExpression: function($viewValue, $modelValue, scope) {
+          return hideDiseaseFields(scope.model);
+        }
       },
       {
         key: 'description',

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -106,7 +106,7 @@
     });
 
     // form helper functions
-    var hideDiseaseFields = function(model) {
+    var hideDiseaseField = function(model) {
       var isFunctional = model.evidence_type === 'Functional';
       var isOncogenic = model.clinical_significance === 'Oncogenic';
       return (isFunctional && !isOncogenic);
@@ -426,6 +426,53 @@
         }
       },
       {
+        key: 'evidence_type',
+        type: 'horizontalSelectHelp',
+        wrapper: 'attributeDefinition',
+        controller: /* @ngInject */ function($scope, $stateParams, ConfigService, _) {
+          if($stateParams.evidenceType) {
+            var et = $stateParams.evidenceType;
+            var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_type.evidence_item);
+            if(_.includes(permitted, et)) {
+              $scope.model.evidence_type = $stateParams.evidenceType;
+              $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[et];
+            } else {
+              console.warn('Ignoring pre-population of Evidence Type with invalid value: ' + et);
+            }
+          }
+        },
+        templateOptions: {
+          label: 'Evidence Type',
+          required: true,
+          value: 'vm.newEvidence.evidence_type',
+          ngOptions: 'option["value"] as option["label"] for option in to.options',
+          options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type.evidence_item)),
+          onChange: function(value, options, scope) {
+            // reset evidence_direction and clinical_significance, as their options will change
+            // also update $touched so user notices
+            var csField = _.find(scope.fields, { key: 'clinical_significance'});
+            var edField = _.find(scope.fields, { key: 'evidence_direction'});
+
+            csField.value('');
+            edField.value('');
+            csField.templateOptions.data.attributeDefinition = '';
+            edField.templateOptions.data.attributeDefinition = '';
+
+            // if we're switching to Predictive, seed the drugs array w/ a blank entry,
+            // otherwise set to empty array
+            value === 'Predictive' ? scope.model.drugs = [''] : scope.model.drugs = [];
+
+            // set attribute definition
+            options.templateOptions.data.attributeDefinition = options.templateOptions.data.attributeDefinitions[value];
+          },
+          helpText: help['Evidence Type'],
+          data: {
+            attributeDefinition: '&nbsp;',
+            attributeDefinitions: descriptions.evidence_type.evidence_item
+          }
+        }
+      },
+      {
         key: 'disease',
         type: 'horizontalTypeaheadHelp',
         wrapper: ['loader', 'diseasedisplay'],
@@ -485,7 +532,7 @@
           'templateOptions.required': 'model.noDoid === false' // required only if noDoid is unchecked
         },
         hideExpression: function($viewValue, $modelValue, scope) {
-          return hideDiseaseFields(scope.model) || scope.model.noDoid;
+          return hideDiseaseField(scope.model) || scope.model.noDoid;
         }
       },
       {
@@ -513,7 +560,7 @@
 
         },
         hideExpression: function($viewValue, $modelValue, scope) {
-          return hideDiseaseFields(scope.model);
+          return hideDiseaseField(scope.model);
         }
       },
       {
@@ -526,53 +573,6 @@
           value: 'vm.newEvidence.description',
           minLength: 32,
           helpText: help['Evidence Statement']
-        }
-      },
-      {
-        key: 'evidence_type',
-        type: 'horizontalSelectHelp',
-        wrapper: 'attributeDefinition',
-        controller: /* @ngInject */ function($scope, $stateParams, ConfigService, _) {
-          if($stateParams.evidenceType) {
-            var et = $stateParams.evidenceType;
-            var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.evidence_type.evidence_item);
-            if(_.includes(permitted, et)) {
-              $scope.model.evidence_type = $stateParams.evidenceType;
-              $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[et];
-            } else {
-              console.warn('Ignoring pre-population of Evidence Type with invalid value: ' + et);
-            }
-          }
-        },
-        templateOptions: {
-          label: 'Evidence Type',
-          required: true,
-          value: 'vm.newEvidence.evidence_type',
-          ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type.evidence_item)),
-          onChange: function(value, options, scope) {
-            // reset evidence_direction and clinical_significance, as their options will change
-            // also update $touched so user notices
-            var csField = _.find(scope.fields, { key: 'clinical_significance'});
-            var edField = _.find(scope.fields, { key: 'evidence_direction'});
-
-            csField.value('');
-            edField.value('');
-            csField.templateOptions.data.attributeDefinition = '';
-            edField.templateOptions.data.attributeDefinition = '';
-
-            // if we're switching to Predictive, seed the drugs array w/ a blank entry,
-            // otherwise set to empty array
-            value === 'Predictive' ? scope.model.drugs = [''] : scope.model.drugs = [];
-
-            // set attribute definition
-            options.templateOptions.data.attributeDefinition = options.templateOptions.data.attributeDefinitions[value];
-          },
-          helpText: help['Evidence Type'],
-          data: {
-            attributeDefinition: '&nbsp;',
-            attributeDefinitions: descriptions.evidence_type.evidence_item
-          }
         }
       },
       {

--- a/src/app/views/add/evidence/addEvidenceBasic.js
+++ b/src/app/views/add/evidence/addEvidenceBasic.js
@@ -473,6 +473,63 @@
         }
       },
       {
+        key: 'clinical_significance',
+        type: 'horizontalSelectHelp',
+        wrapper: 'attributeDefinition',
+        controller: /* @ngInject */ function($scope, $stateParams, ConfigService, _) {
+          if($stateParams.clinicalSignificance) {
+            // ensure evidence type defined before setting evidence direction
+            if($stateParams.evidenceType) {
+              var et = $stateParams.evidenceType;
+              var cs = $stateParams.clinicalSignificance;
+              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.clinical_significance.evidence_item[et]);
+              if(_.includes(permitted, cs)) {
+                $scope.model.clinical_significance = $stateParams.clinicalSignificance;
+                $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[cs];
+              } else {
+                console.warn('Ignoring pre-population of Clinical Significance with invalid value: ' + cs);
+              }
+
+            } else {
+              console.warn('Cannot pre-populate Clinical Significance without specifying Evidence Type.');
+            }
+          }
+        },
+        templateOptions: {
+          label: 'Clinical Significance',
+          required: true,
+          value: 'vm.newEvidence.clinical_significance',
+          // stores unmodified options array for expressionProperties
+          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
+          ngOptions: 'option["value"] as option["label"] for option in to.options',
+          // actual options displayed in the select, modified by expressionProperties
+          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
+          helpText: help['Clinical Significance'],
+          data: {
+            attributeDefinition: 'Please choose Evidence Type before selecting Clinical Significance.',
+            attributeDefinitions: merge_props(descriptions.clinical_significance.evidence_item),
+            updateDefinition: function(value, options, scope) {
+              // set attribute definition
+              options.templateOptions.data.attributeDefinition =
+                options.templateOptions.data.attributeDefinitions[scope.model.clinical_significance];
+            }
+          },
+          onChange: function(value, options, scope) {
+            options.templateOptions.data.updateDefinition(value, options, scope);
+          }
+        },
+        expressionProperties: {
+          'templateOptions.options': function($viewValue, $modelValue, scope) {
+            return  _.filter(scope.to.clinicalSignificanceOptions, function(option) {
+              return !!(option.type === scope.model.evidence_type ||
+                        option.type === 'default' ||
+                        option.type === 'N/A');
+            });
+          },
+          'templateOptions.disabled': 'model.evidence_type === ""' // deactivate if evidence_type unselected
+        }
+      },
+      {
         key: 'disease',
         type: 'horizontalTypeaheadHelp',
         wrapper: ['loader', 'diseasedisplay'],
@@ -656,63 +713,6 @@
         expressionProperties: {
           'templateOptions.options': function($viewValue, $modelValue, scope) {
             return  _.filter(scope.to.evidenceDirectionOptions, function(option) {
-              return !!(option.type === scope.model.evidence_type ||
-                        option.type === 'default' ||
-                        option.type === 'N/A');
-            });
-          },
-          'templateOptions.disabled': 'model.evidence_type === ""' // deactivate if evidence_type unselected
-        }
-      },
-      {
-        key: 'clinical_significance',
-        type: 'horizontalSelectHelp',
-        wrapper: 'attributeDefinition',
-        controller: /* @ngInject */ function($scope, $stateParams, ConfigService, _) {
-          if($stateParams.clinicalSignificance) {
-            // ensure evidence type defined before setting evidence direction
-            if($stateParams.evidenceType) {
-              var et = $stateParams.evidenceType;
-              var cs = $stateParams.clinicalSignificance;
-              var permitted = _.keys(ConfigService.evidenceAttributeDescriptions.clinical_significance.evidence_item[et]);
-              if(_.includes(permitted, cs)) {
-                $scope.model.clinical_significance = $stateParams.clinicalSignificance;
-                $scope.to.data.attributeDefinition = $scope.to.data.attributeDefinitions[cs];
-              } else {
-                console.warn('Ignoring pre-population of Clinical Significance with invalid value: ' + cs);
-              }
-
-            } else {
-              console.warn('Cannot pre-populate Clinical Significance without specifying Evidence Type.');
-            }
-          }
-        },
-        templateOptions: {
-          label: 'Clinical Significance',
-          required: true,
-          value: 'vm.newEvidence.clinical_significance',
-          // stores unmodified options array for expressionProperties
-          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
-          ngOptions: 'option["value"] as option["label"] for option in to.options',
-          // actual options displayed in the select, modified by expressionProperties
-          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
-          helpText: help['Clinical Significance'],
-          data: {
-            attributeDefinition: 'Please choose Evidence Type before selecting Clinical Significance.',
-            attributeDefinitions: merge_props(descriptions.clinical_significance.evidence_item),
-            updateDefinition: function(value, options, scope) {
-              // set attribute definition
-              options.templateOptions.data.attributeDefinition =
-                options.templateOptions.data.attributeDefinitions[scope.model.clinical_significance];
-            }
-          },
-          onChange: function(value, options, scope) {
-            options.templateOptions.data.updateDefinition(value, options, scope);
-          }
-        },
-        expressionProperties: {
-          'templateOptions.options': function($viewValue, $modelValue, scope) {
-            return  _.filter(scope.to.clinicalSignificanceOptions, function(option) {
               return !!(option.type === scope.model.evidence_type ||
                         option.type === 'default' ||
                         option.type === 'N/A');

--- a/src/app/views/add/evidence/addEvidenceBasic.tpl.html
+++ b/src/app/views/add/evidence/addEvidenceBasic.tpl.html
@@ -128,21 +128,21 @@
     </div>
   </div>
 
-  <div class="row">
-    <!-- <div class="col-xs-4">
-         <h3>vm.newEvidence</h3>
-         <pre ng-bind="vm.newEvidence|json" class="small"></pre>
-         <h3>submit button stuff</h3>
-         <p>vm.form.$invalid: {{vm.form.$invalid}}</p>
-         <p>vm.isAuthenticated: {{vm.isAuthenticated}}</p>
-         </div> -->
-    <div class="col-xs-12">
-      <h3>vm.form</h3>
-      <pre ng-bind="vm.form['$error'].required|json" class="small"></pre>
-    </div>
-    <!-- <div class="col-xs-6">
-         <h3>vm.evidenceFields</h3>
-         <pre ng-bind="vm.evidenceFields|json" class="small"></pre>
-         </div> -->
-  </div>
+  <!-- <div class="row">
+       <div class="col-xs-4">
+       <h3>vm.newEvidence</h3>
+       <pre ng-bind="vm.newEvidence|json" class="small"></pre>
+       <h3>submit button stuff</h3>
+       <p>vm.form.$invalid: {{vm.form.$invalid}}</p>
+       <p>vm.isAuthenticated: {{vm.isAuthenticated}}</p>
+       </div>
+       <div class="col-xs-4">
+       <h3>vm.form</h3>
+       <pre ng-bind="vm.form|json" class="small"></pre>
+       </div>
+       <div class="col-xs-4">
+       <h3>vm.evidenceFields</h3>
+       <pre ng-bind="vm.evidenceFields|json" class="small"></pre>
+       </div>
+       </div> -->
 </div>

--- a/src/app/views/add/evidence/addEvidenceBasic.tpl.html
+++ b/src/app/views/add/evidence/addEvidenceBasic.tpl.html
@@ -128,21 +128,21 @@
     </div>
   </div>
 
-  <!-- <div class="row"> -->
-  <!-- <div class="col-xs-4"> -->
-  <!-- <h3>vm.newEvidence</h3> -->
-  <!-- <pre ng-bind="vm.newEvidence|json" class="small"></pre> -->
-  <!-- <h3>submit button stuff</h3> -->
-  <!-- <p>vm.form.$invalid: {{vm.form.$invalid}}</p> -->
-  <!-- <p>vm.isAuthenticated: {{vm.isAuthenticated}}</p> -->
-  <!-- </div> -->
-  <!-- <div class="col-xs-4"> -->
-  <!-- <h3>vm.form</h3> -->
-  <!-- <pre ng-bind="vm.form|json" class="small"></pre> -->
-  <!-- </div> -->
-  <!-- <div class="col-xs-4"> -->
-  <!-- <h3>vm.evidenceFields</h3> -->
-  <!-- <pre ng-bind="vm.evidenceFields|json" class="small"></pre> -->
-  <!-- </div> -->
-  <!-- </div> -->
+  <div class="row">
+    <!-- <div class="col-xs-4">
+         <h3>vm.newEvidence</h3>
+         <pre ng-bind="vm.newEvidence|json" class="small"></pre>
+         <h3>submit button stuff</h3>
+         <p>vm.form.$invalid: {{vm.form.$invalid}}</p>
+         <p>vm.isAuthenticated: {{vm.isAuthenticated}}</p>
+         </div> -->
+    <div class="col-xs-12">
+      <h3>vm.form</h3>
+      <pre ng-bind="vm.form['$error'].required|json" class="small"></pre>
+    </div>
+    <!-- <div class="col-xs-6">
+         <h3>vm.evidenceFields</h3>
+         <pre ng-bind="vm.evidenceFields|json" class="small"></pre>
+         </div> -->
+  </div>
 </div>

--- a/src/app/views/add/evidence/addEvidenceDuplicateWarning.tpl.html
+++ b/src/app/views/add/evidence/addEvidenceDuplicateWarning.tpl.html
@@ -1,18 +1,20 @@
-<div class="row" ng-show="vm.duplicates.length > 0">
-  <div class="col-xs-offset-1 col-xs-10">
-    <div class="alert alert-warning">
-      <p>Evidence items already exist that use <em ng-bind="pubmedField.templateOptions.data.description">this publication</em> to support a clinical interpretation of a mutation in {{model.gene.name}} {{model.variant.name}}. Please check the following evidence items to ensure that your intended contribution does not replicate the efforts of other curators:</p>
-      <evidence-grid
-        style="background-color: white;border-radius: 8px;margin-top: 1em; padding: .5em;"
-        evidence="vm.duplicates"
-        variant="model.variant.name"
-        show-gene-col="false"
-        show-variant-col="false"
-        rounded="true"
-        context="'conflict'"
-        rows="3">
+<div class="duplicate-warning" >
+  <div class="row" ng-show="vm.duplicates.length > 0">
+    <div class="col-xs-offset-1 col-xs-10">
+      <div class="alert alert-warning">
+        <p>Evidence items already exist that use <em ng-bind="sourceField.templateOptions.data.citation">this publication</em> to support a clinical interpretation of a mutation in {{model.gene.name}} {{model.variant.name}}. Please check the following evidence items to ensure that your intended contribution does not replicate the efforts of other curators:</p>
+        <evidence-grid
+          style="background-color: white;border-radius: 8px;margin-top: 1em; padding: .5em;"
+          evidence="vm.duplicates"
+          variant="model.variant.name"
+          show-gene-col="false"
+          show-variant-col="false"
+          rounded="true"
+          context="'conflict'"
+          rows="3">
 
-      </evidence-grid>
+        </evidence-grid>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/views/browse/directives/browseGrid.js
+++ b/src/app/views/browse/directives/browseGrid.js
@@ -514,6 +514,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
+              { value: 'Oncogenic', label: 'Oncogenic' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/common/evidenceGrid.js
+++ b/src/app/views/events/common/evidenceGrid.js
@@ -342,6 +342,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
+              { value: 'Oncogenic', label: 'Oncogenic'},
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/common/evidenceGridClinicalSignificanceCell.tpl.html
+++ b/src/app/views/events/common/evidenceGridClinicalSignificanceCell.tpl.html
@@ -26,6 +26,7 @@
     'glyphicon-resize-horizontal' : row.entity[col.field] === 'Unaltered Function',
     'glyphicon-exclamation-sign' : row.entity[col.field] === 'Neomorphic',
     'glyphicon-resize-full' : row.entity[col.field] === 'Dominant Negative',
+    'glyphicon-certificate': row.entity[col.field] === 'Oncogenic',
     'glyphicon-log-out' : row.entity[col.field] === 'Unknown',}">
   </span>
 </div>

--- a/src/app/views/events/common/evidenceGridPopoverKey.tpl.html
+++ b/src/app/views/events/common/evidenceGridPopoverKey.tpl.html
@@ -486,6 +486,14 @@
               </tr>
               <tr>
                 <td class="symbol clinicalCell">
+                  <span class="glyphicon glyphicon-certificate"></span>
+                </td>
+                <td class="symbol-description">
+                  Oncogenic
+                </td>
+              </tr>
+              <tr>
+                <td class="symbol clinicalCell">
                   <span class="glyphicon glyphicon-log-out"></span>
                 </td>
                 <td class="symbol-description">

--- a/src/app/views/events/common/evidenceSelector/evidenceSelector.js
+++ b/src/app/views/events/common/evidenceSelector/evidenceSelector.js
@@ -320,6 +320,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
+              { value: 'Oncogenic', name: 'Oncogenic' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]
@@ -531,6 +532,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
+              { value: 'Oncogenic', name: 'Oncogenic' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/common/evidenceSelector/evidenceSelector.js
+++ b/src/app/views/events/common/evidenceSelector/evidenceSelector.js
@@ -320,7 +320,7 @@
               { value: 'Unaltered Function', label: 'Unaltered Function'},
               { value: 'Neomorphic', label: 'Neomorphic'},
               { value: 'Dominant Negative', label: 'Dominant Negative' },
-              { value: 'Oncogenic', name: 'Oncogenic' },
+              { value: 'Oncogenic', label: 'Oncogenic' },
               { value: 'Unknown', label: 'Unknown'},
               { value: 'N/A', label: 'N/A' }
             ]

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -233,6 +233,86 @@
         }
       },
       {
+        key: 'evidence_type',
+        type: 'horizontalSelectHelp',
+        wrapper: 'attributeDefinition',
+        controller: /* @ngInject */  function($scope) {
+          // set attribute definition
+          $scope.options.templateOptions.data.attributeDefinition =
+            $scope.options.templateOptions.data.attributeDefinitions[$scope.model.evidence_type];
+        },
+        templateOptions: {
+          label: 'Evidence Type',
+          required: true,
+          value: 'vm.evidenceEdit.evidence_type',
+          ngOptions: 'option["value"] as option["label"] for option in to.options',
+          options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type.evidence_item)),
+          onChange: function(value, options, scope) {
+            // reset clinical_significance, as its options will change
+            // then update $touched to ensure user notices
+            var csField = _.find(scope.fields, { key: 'clinical_significance'});
+            var edField = _.find(scope.fields, { key: 'evidence_direction'});
+
+            csField.value('');
+            edField.value('');
+            csField.templateOptions.data.attributeDefinition = '';
+            edField.templateOptions.data.attributeDefinition = '';
+
+            // if we're switching to Predictive, seed the drugs array w/ a blank entry,
+            // otherwise set to empty array
+            value === 'Predictive' ? scope.model.drugs = [''] : scope.model.drugs = [];
+
+            // set attribute definition
+            options.templateOptions.data.attributeDefinition = options.templateOptions.data.attributeDefinitions[value];
+
+          },
+          helpText: help['Evidence Type'],
+          data: {
+            attributeDefinition: '&nbsp;',
+            attributeDefinitions: descriptions.evidence_type
+          }
+        }
+      },
+      {
+        key: 'clinical_significance',
+        type: 'horizontalSelectHelp',
+        wrapper: 'attributeDefinition',
+        controller: /* @ngInject */ function($scope) {
+          // set attribute definition
+          $scope.options.templateOptions.data.attributeDefinition =
+            $scope.options.templateOptions.data.attributeDefinitions[$scope.model.evidence_type][$scope.model.clinical_significance];
+        },
+        templateOptions: {
+          label: 'Clinical Significance',
+          required: true,
+          value: 'vm.evidenceEdit.clinical_significance',
+          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
+          ngOptions: 'option["value"] as option["label"] for option in to.options',
+          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
+          helpText: help['Clinical Significance'],
+          data: {
+            attributeDefinition: '&nbsp;',
+            attributeDefinitions: descriptions.clinical_significance.evidence_item,
+            updateDefinition: function(value, options, scope) {
+              // set attribute definition
+              options.templateOptions.data.attributeDefinition =
+                options.templateOptions.data.attributeDefinitions[scope.model.evidence_type][scope.model.clinical_significance];
+            }
+          },
+          onChange: function(value, options, scope) {
+            options.templateOptions.data.updateDefinition(value, options, scope);
+          }
+        },
+        expressionProperties: {
+          'templateOptions.options': function($viewValue, $modelValue, scope) {
+            return  _.filter(scope.to.clinicalSignificanceOptions, function(option) {
+              return !!(option.type === scope.model.evidence_type || option.type === 'default' || option.type === 'N/A');
+            });
+          },
+          'templateOptions.disabled': 'model.evidence_type === ""' // deactivate if evidence_type unselected
+        }
+      },
+      {
         key: 'disease',
         type: 'horizontalTypeaheadHelp',
         wrapper: ['loader', 'diseasedisplay', 'validationMessages'],
@@ -275,6 +355,17 @@
         hideExpression: 'model.noDoid'
       },
       {
+        key: 'disease_name',
+        type: 'horizontalInputHelp',
+        templateOptions: {
+          label: 'Disease Name',
+          required: true,
+          minLength: 32,
+          helpText: help['Disease Name']
+        },
+        hideExpression: '!model.noDoid'
+      },
+      {
         key: 'noDoid',
         type: 'horizontalCheckbox',
         templateOptions: {
@@ -287,17 +378,6 @@
         }
       },
       {
-        key: 'disease_name',
-        type: 'horizontalInputHelp',
-        templateOptions: {
-          label: 'Disease Name',
-          required: true,
-          minLength: 32,
-          helpText: help['Disease Name']
-        },
-        hideExpression: '!model.noDoid'
-      },
-      {
         key: 'description',
         type: 'horizontalTextareaHelp',
         templateOptions: {
@@ -306,47 +386,6 @@
           label: 'Evidence Statement',
           minLength: 32,
           helpText: help['Evidence Statement']
-        }
-      },
-      {
-        key: 'evidence_type',
-        type: 'horizontalSelectHelp',
-        wrapper: 'attributeDefinition',
-        controller: /* @ngInject */  function($scope) {
-          // set attribute definition
-          $scope.options.templateOptions.data.attributeDefinition =
-            $scope.options.templateOptions.data.attributeDefinitions[$scope.model.evidence_type];
-        },
-        templateOptions: {
-          label: 'Evidence Type',
-          required: true,
-          value: 'vm.evidenceEdit.evidence_type',
-          ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: [{ value: '', label: 'Please select an Evidence Type' }].concat(make_options(descriptions.evidence_type.evidence_item)),
-          onChange: function(value, options, scope) {
-            // reset clinical_significance, as its options will change
-            // then update $touched to ensure user notices
-            var csField = _.find(scope.fields, { key: 'clinical_significance'});
-            var edField = _.find(scope.fields, { key: 'evidence_direction'});
-
-            csField.value('');
-            edField.value('');
-            csField.templateOptions.data.attributeDefinition = '';
-            edField.templateOptions.data.attributeDefinition = '';
-
-            // if we're switching to Predictive, seed the drugs array w/ a blank entry,
-            // otherwise set to empty array
-            value === 'Predictive' ? scope.model.drugs = [''] : scope.model.drugs = [];
-
-            // set attribute definition
-            options.templateOptions.data.attributeDefinition = options.templateOptions.data.attributeDefinitions[value];
-
-          },
-          helpText: help['Evidence Type'],
-          data: {
-            attributeDefinition: '&nbsp;',
-            attributeDefinitions: descriptions.evidence_type
-          }
         }
       },
       {
@@ -410,45 +449,6 @@
         expressionProperties:{
           'templateOptions.options': function($viewValue, $modelValue, scope) {
             return  _.filter(scope.to.evidenceDirectionOptions, function(option) {
-              return !!(option.type === scope.model.evidence_type || option.type === 'default' || option.type === 'N/A');
-            });
-          },
-          'templateOptions.disabled': 'model.evidence_type === ""' // deactivate if evidence_type unselected
-        }
-      },
-      {
-        key: 'clinical_significance',
-        type: 'horizontalSelectHelp',
-        wrapper: 'attributeDefinition',
-        controller: /* @ngInject */ function($scope) {
-          // set attribute definition
-          $scope.options.templateOptions.data.attributeDefinition =
-            $scope.options.templateOptions.data.attributeDefinitions[$scope.model.evidence_type][$scope.model.clinical_significance];
-        },
-        templateOptions: {
-          label: 'Clinical Significance',
-          required: true,
-          value: 'vm.evidenceEdit.clinical_significance',
-          clinicalSignificanceOptions: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
-          ngOptions: 'option["value"] as option["label"] for option in to.options',
-          options: [{ type: 'default', value: '', label: 'Please select a Clinical Significance' }].concat(cs_options(descriptions.clinical_significance.evidence_item)),
-          helpText: help['Clinical Significance'],
-          data: {
-            attributeDefinition: '&nbsp;',
-            attributeDefinitions: descriptions.clinical_significance.evidence_item,
-            updateDefinition: function(value, options, scope) {
-              // set attribute definition
-              options.templateOptions.data.attributeDefinition =
-                options.templateOptions.data.attributeDefinitions[scope.model.evidence_type][scope.model.clinical_significance];
-            }
-          },
-          onChange: function(value, options, scope) {
-            options.templateOptions.data.updateDefinition(value, options, scope);
-          }
-        },
-        expressionProperties: {
-          'templateOptions.options': function($viewValue, $modelValue, scope) {
-            return  _.filter(scope.to.clinicalSignificanceOptions, function(option) {
               return !!(option.type === scope.model.evidence_type || option.type === 'default' || option.type === 'N/A');
             });
           },

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -103,6 +103,17 @@
       return (isFunctional && !isOncogenic);
     };
 
+    var resetDiseaseFields = function(scope) {
+      var disField = _.find(scope.fields, { key: 'disease'});
+      var noDoidField = _.find(scope.fields, { key: 'noDoid'});
+      var disNameField = _.find(scope.fields, { key: 'disease_name'});
+
+      disField.value({name: ''});
+      noDoidField.value(false);
+      // disease name field may not be instantiated with a value func
+      if(disNameField.value) { disNameField.value(''); }
+    };
+
     vm.evidenceFields = [
       {
         key: 'variant_origin',
@@ -265,6 +276,11 @@
             csField.templateOptions.data.attributeDefinition = '';
             edField.templateOptions.data.attributeDefinition = '';
 
+            // reset disease fields if switching to Functional
+            if(value === 'Functional') {
+              resetDiseaseFields(scope);
+            }
+
             // if we're switching to Predictive, seed the drugs array w/ a blank entry,
             // otherwise set to empty array
             value === 'Predictive' ? scope.model.drugs = [''] : scope.model.drugs = [];
@@ -308,6 +324,12 @@
           },
           onChange: function(value, options, scope) {
             options.templateOptions.data.updateDefinition(value, options, scope);
+
+            // if switching from Functional Oncogenic, reset disease fields
+            var etField = _.find(scope.fields, { key: 'evidence_type'});
+            if(etField.value() === 'Functional' && value !== 'Oncogenic') {
+              resetDiseaseFields(scope);
+            }
           }
         },
         expressionProperties: {

--- a/src/app/views/events/evidence/edit/evidenceEditBasic.js
+++ b/src/app/views/events/evidence/edit/evidenceEditBasic.js
@@ -96,6 +96,13 @@
       $document.scrollToElementAnimated(elem);
     });
 
+    // form helper functions
+    var hideDiseaseField = function(model) {
+      var isFunctional = model.evidence_type === 'Functional';
+      var isOncogenic = model.clinical_significance === 'Oncogenic';
+      return (isFunctional && !isOncogenic);
+    };
+
     vm.evidenceFields = [
       {
         key: 'variant_origin',
@@ -352,7 +359,9 @@
           'templateOptions.disabled': 'model.noDoid === true', // deactivate if noDoid is checked
           'templateOptions.required': 'model.noDoid === false' // required only if noDoid is unchecked
         },
-        hideExpression: 'model.noDoid'
+        hideExpression: function($viewValue, $modelValue, scope) {
+          return hideDiseaseField(scope.model) || scope.model.noDoid;
+        }
       },
       {
         key: 'disease_name',
@@ -375,6 +384,9 @@
               scope.model.disease = '';
             }
           }
+        },
+        hideExpression: function($viewValue, $modelValue, scope) {
+          return hideDiseaseField(scope.model);
         }
       },
       {

--- a/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
+++ b/src/app/views/events/evidence/summary/evidenceSummary.tpl.html
@@ -101,7 +101,7 @@
           <col width="60%"/>
         </colgroup>
 
-        <tr>
+        <tr ng-if="evidence.evidence_type !== 'Functional' || (evidence.evidence_type === 'Functional' && evidence.clinical_significance === 'Oncogenic')">
           <td class="name">Disease:</td>
           <td class="value">
             <span ng-switch="evidence.disease.doid !== null" >
@@ -267,11 +267,6 @@
       </a>
     </div>
   </div>
-  <!--<div class="row">-->
-  <!--<div class="col-xs-12">-->
-  <!--<pre ng-bind="evidence|json">evidence</pre>-->
-  <!--</div>-->
-  <!--</div>-->
 </div>
 
 <script type="text/ng-template" id="org-menu.tpl.html">

--- a/src/app/views/search/config/EvidenceItemFieldConfig.js
+++ b/src/app/views/search/config/EvidenceItemFieldConfig.js
@@ -566,6 +566,7 @@
                           { value: 'Unaltered Function', name: 'Unaltered Function'},
                           { value: 'Neomorphic', name: 'Neomorphic'},
                           { value: 'Dominant Negative', name: 'Dominant Negative' },
+                          { value: 'Oncogenic', name: 'Oncogenic' },
                           { value: 'Unknown', name: 'Unknown'},
                           { value: 'N/A', name: 'N/A' }
                         ]

--- a/src/components/directives/evidenceSelectorItem.tpl.html
+++ b/src/components/directives/evidenceSelectorItem.tpl.html
@@ -101,7 +101,7 @@
           <col width="60%" />
         </colgroup>
 
-        <tr>
+        <tr ng-if="ctrl.item.evidence_type !== 'Functional' || (ctrl.item.evidence_type === 'Functional' && ctrl.item.clinical_significance === 'Oncogenic')">
           <td class="name">Disease:</td>
           <td class="value">
             <a target="_blank" href="{{ ctrl.item.disease.url }}" _target="blank">

--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -257,6 +257,7 @@
               'Unaltered Function': 'Gene product of sequence variant is unchanged',
               'Neomorphic': 'Sequence variant creates a novel function',
               'Dominant Negative': 'Seuqnce variant abolishes wild type allele function',
+              'Oncogenic': 'Sequence variant that induces or increases oncogenic cellular potential',
               'Unknown': 'Sequence variant that cannot be precisely defined the other listed categories',
             },
           },


### PR DESCRIPTION
Closes #1455, requires griffithlab/civic-server#664, and includes all commits from PR #1562.

This PR updates Add & Edit Evidence forms, and Evidence summaries to hide disease fields for Functional evidence types with non-oncogenic clinical significance.

I also updated the order of the fields on the Add and Edit Evidence forms, as fields which effect the display or values of other fields should appear before the fields they effect. Therefore, Evidence Type and Clinical Significance fields appear above the Disease fields instead of below:

<img width="651" alt="Screen Shot 2020-12-14 at 17 39 55" src="https://user-images.githubusercontent.com/132909/102149140-62656b00-3e33-11eb-8cad-d669f46a0cf8.png">