### PR TITLE
removed 'Oncogenic' as an clinical significance select option for Functional evidence types

### DIFF
--- a/src/components/services/ConfigService.js
+++ b/src/components/services/ConfigService.js
@@ -257,7 +257,6 @@
               'Unaltered Function': 'Gene product of sequence variant is unchanged',
               'Neomorphic': 'Sequence variant creates a novel function',
               'Dominant Negative': 'Seuqnce variant abolishes wild type allele function',
-              'Oncogenic': 'Sequence variant that induces or increases oncogenic cellular potential',
               'Unknown': 'Sequence variant that cannot be precisely defined the other listed categories',
             },
           },


### PR DESCRIPTION
This hotfix allows us to deploy now while we hammer out the details for functional oncogenic evidence.