### PR TITLE
Evidence advanced search page now includes a Pediatric Cancers example search

### DIFF
--- a/src/app/pages/home.tpl.html
+++ b/src/app/pages/home.tpl.html
@@ -57,6 +57,15 @@
     <div class="col-xs-12 col-md-6" >
       <div class="announcement" >
         <div class="announcement-body" style="margin-bottom: 1em;">
+          <p class="date">February 12th, 2021</p>
+          <p><span style="color:#faa51b;">Pediatric Cancer Variants:</span> Through support from the Childhood Cancer Data Initiative (CCDI), we have executed our initial phase of highlighting pediatric cancer variant content. This <a href="https://civicdb.org/search/evidence/9dfdc53d-4022-43b1-8f3a-6b6bf81caff6"  target="_blank" uib-tooltip="Pediatric Cancer Variants Advanced Search"> advanced search query</a> displays childhood relevant data contained in CIViC. Stay tuned for more pediatric-focused features as we launch the first open-access searchable childhood-cancer-specific dataset.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-md-6" >
+      <div class="announcement" >
+        <div class="announcement-body" style="margin-bottom: 1em;">
           <p class="date">June 29th, 2020</p>
           <div class="row" >
             <div class="col-xs-6">
@@ -69,17 +78,6 @@
               </p>
             </div>
           </div>
-        </div>
-      </div>
-    </div>
-    <div class="col-xs-12 col-md-6" >
-      <div class="announcement" >
-        <div class="announcement-body" style="margin-bottom: 1em;">
-          <p class="date">May 20th, 2019</p>
-          <p><span style="color:#faa51b;">New YouTube Tutorials:</span> We've updated the <a href="https://www.youtube.com/playlist?list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX" target="_blank" uib-tooltip="CIViC Tutorials Playlist">CIViC Help playlist</a> with a variety of new video tutorials, helping you to <a href="https://www.youtube.com/watch?v=Vr0BDUKkDeI&list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX&index=2" target="_blank" uib-tooltip="CIViC tutorial - getting started" target="_blank">get started</a> collaborating with us</a> by <a href="https://www.youtube.com/watch?v=7MCWt9qB528&list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX&index=9" target="_blank" uib-tooltip="Collaborating with CIViC Source Suggestions">suggesting sources</a>, <a href="https://www.youtube.com/watch?v=od5Tgdfo6Qs&list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX&index=3" target="_blank" uib-tooltip="CIViC tutorial - Adding evidence">adding</a> and <a href="https://www.youtube.com/watch?v=uss4R20ymPA&list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX&index=3" target="_blank" uib-tooltip="CIViC tutorial - Editing">editing evidence</a>, <a href="https://www.youtube.com/watch?v=Nx8yMcbE2PA&list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX&index=7" target="_blank" uib-tooltip="Adoption of Variant Interpretation Standards and Guidelines in CIViC">and</a> <a href="https://www.youtube.com/watch?v=XVO2_amcF4I&list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX&index=5" target="_blank" uib-tooltip="Collaborating with CIViC Assertions">more</a>. Also, we've produced videos that provide details about our <a href="https://www.youtube.com/watch?v=hGPd1R4-dfQ&list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX&index=6" target="_blank" uib-tooltip="Collaboration between ClinGen Somatic Cancer Clinical Domain Working Group and CIViC">collaborations with ClinGen Working Groups</a> and <a href="https://www.youtube.com/watch?v=nSm-WHpgLCI&list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX&index=4" target="_blank" uib-tooltip="Collaborative Opportunities in CIViC">a new introdution to CIViC collaboration opportunities</a>.
-          </p>
-          <p>Please watch the <a href="https://www.youtube.com/playlist?list=PLImz36orVFPCQjx6wjMrYW-IPWGk8HrbX" target="_blank" uib-tooltip="CIViC Tutorials Playlist">new videos</a>, review <a href="https://civic.readthedocs.io/en/latest/" target="_blank" uib-tooltip="CIViC Documentation: Introduction to CIViC">the documentation</a>, and join in helping us curate clinical variants.</p>
-          <p><a href="https://www.youtube.com/channel/UCtZ14M7ZNmMDivSJzaHO8BQ" target="_blank" uib-tooltip="CIViC YouTube Channel">Subscribe to our YouTube channel</a> for future tutorials and presentations!</p>
         </div>
       </div>
     </div>

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -61,6 +61,13 @@
       ],
       'variants': [
         {
+          name: 'Pediatric Cancers',
+          tooltip: '',
+          search:{"operator":"OR","queries":[{"field":"disease_name","condition":{"name":"contains","parameters":["pediatric"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["childhood"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["infantile"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["juvenile"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["teenage"]}}],"entity":"evidence_items"}
+
+
+        },
+        {
           name: 'CHR1 Chromosome is 2',
           tooltip: 'Variants with a primary chromosome of 2',
           search: {'operator':'AND','queries':[{'field':'chromosome','condition':{'name':'is_equal_to','parameters':['2']}}]}

--- a/src/app/views/search/SearchController.js
+++ b/src/app/views/search/SearchController.js
@@ -32,6 +32,13 @@
       ],
       'evidence': [
         {
+          name: 'Pediatric Cancers',
+          tooltip: '',
+          search:{"operator":"OR","queries":[{"field":"disease_name","condition":{"name":"contains","parameters":["pediatric"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["childhood"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["infantile"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["juvenile"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["teenage"]}}],"entity":"evidence_items"}
+
+
+        },
+        {
           name: 'High Quality ALK Evidence',
           tooltip: 'Evidence pertaining to ALK variants with high Evidence Levels and Ratings',
           search: {'operator':'AND','queries':[{'field':'gene_name','condition':{'name':'contains','parameters':['ALK']}},{'field':'rating','condition':{'name':'is_greater_than_or_equal_to','parameters':[4]}},{'field':'evidence_level','condition':{'name':'is_above','parameters':['C']}}]}
@@ -60,13 +67,6 @@
         }
       ],
       'variants': [
-        {
-          name: 'Pediatric Cancers',
-          tooltip: '',
-          search:{"operator":"OR","queries":[{"field":"disease_name","condition":{"name":"contains","parameters":["pediatric"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["childhood"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["infantile"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["juvenile"]}},{"field":"disease_name","condition":{"name":"contains","parameters":["teenage"]}}],"entity":"evidence_items"}
-
-
-        },
         {
           name: 'CHR1 Chromosome is 2',
           tooltip: 'Variants with a primary chromosome of 2',

--- a/src/app/views/search/search.less
+++ b/src/app/views/search/search.less
@@ -2,6 +2,7 @@
 @import 'bower_components/bootstrap/less/variables.less';
 @import 'src/app/styles/_civic-variables.less';
 @import 'src/app/styles/_mixins.less';
+@import 'src/app/styles/_buttons.less';
 
 .searchView{
   .title-row {
@@ -44,6 +45,10 @@
           background-color: lighten(@civicLightBlue, 35%);
         }
       }
+    }
+
+    li#pediatric-cancers a {
+      .pretty-buttons(#FFFFFF, #4fc3f7, 0 0 4px #0288d1);
     }
   }
 

--- a/src/app/views/search/templates/searchAssertions.tpl.html
+++ b/src/app/views/search/templates/searchAssertions.tpl.html
@@ -4,7 +4,8 @@
       <div class="well suggested-searches">
         <h4>Example Searches:</h4>
         <ul class="nav nav-pills">
-          <li ng-repeat="suggestion in vm.suggestedSearches.assertions">
+          <li ng-repeat="suggestion in vm.suggestedSearches.assertions"
+            ng-attr-id="{{ suggestion.name | kebabCase }}">
             <a ng-click="vm.setSearch(suggestion.search)"
                uib-tooltip="{{suggestion.tooltip}}"
                ng-bind="suggestion.name">

--- a/src/app/views/search/templates/searchEvidence.tpl.html
+++ b/src/app/views/search/templates/searchEvidence.tpl.html
@@ -4,7 +4,8 @@
       <div class="well suggested-searches">
         <h4>Example Searches:</h4>
         <ul class="nav nav-pills">
-          <li ng-repeat="suggestion in vm.suggestedSearches.evidence">
+          <li ng-repeat="suggestion in vm.suggestedSearches.evidence"
+            ng-attr-id="{{ suggestion.name | kebabCase }}">
             <a ng-click="vm.setSearch(suggestion.search)"
                uib-tooltip="{{suggestion.tooltip}}"
                ng-bind="suggestion.name">

--- a/src/app/views/search/templates/searchGenes.tpl.html
+++ b/src/app/views/search/templates/searchGenes.tpl.html
@@ -4,7 +4,8 @@
       <div class="well suggested-searches">
         <h4>Example Searches:</h4>
         <ul class="nav nav-pills">
-          <li ng-repeat="suggestion in vm.suggestedSearches.genes">
+          <li ng-repeat="suggestion in vm.suggestedSearches.genes"
+            ng-attr-id="{{ suggestion.name | kebabCase }}">
             <a ng-click="vm.setSearch(suggestion.search)"
                uib-tooltip="{{suggestion.tooltip}}"
                tooltip-append-to-body="true"

--- a/src/app/views/search/templates/searchSources.tpl.html
+++ b/src/app/views/search/templates/searchSources.tpl.html
@@ -4,7 +4,8 @@
       <div class="well suggested-searches">
         <h4>Example Searches:</h4>
         <ul class="nav nav-pills">
-          <li ng-repeat="suggestion in vm.suggestedSearches.sources">
+          <li ng-repeat="suggestion in vm.suggestedSearches.sources"
+            ng-attr-id="{{ suggestion.name | kebabCase }}">
             <a ng-click="vm.setSearch(suggestion.search)"
                uib-tooltip="{{suggestion.tooltip}}"
                tooltip-append-to-body="true"

--- a/src/app/views/search/templates/searchVariants.tpl.html
+++ b/src/app/views/search/templates/searchVariants.tpl.html
@@ -4,7 +4,8 @@
       <div class="well suggested-searches">
         <h4>Example Searches:</h4>
         <ul class="nav nav-pills">
-          <li ng-repeat="suggestion in vm.suggestedSearches.variants">
+          <li ng-repeat="suggestion in vm.suggestedSearches.variants"
+            ng-attr-id="{{ suggestion.name | kebabCase }}">
             <a ng-click="vm.setSearch(suggestion.search)"
                uib-tooltip="{{suggestion.tooltip}}"
                tooltip-append-to-body="true"

--- a/src/components/filters.js
+++ b/src/components/filters.js
@@ -1,6 +1,7 @@
 (function() {
   'use strict';
   angular.module('civic.common')
+    .filter('kebabCase', kebabCaseFilter)
     .filter('labelify', labelifyFilter)
     .filter('arrayToList', arrayToListFilter)
     .filter('encodeUri', encodeUri)
@@ -12,6 +13,15 @@
     .filter('keyToLabel', keyToLabel)
     .filter('highlightSearch', highlightSearch)
     .filter('words', words);
+
+  // @ngInject
+  function kebabCaseFilter() {
+    return function(input) {
+      return input.replace(/([a-z])([A-Z])/g, "$1-$2")
+        .replace(/\s+/g, '-')
+        .toLowerCase();
+    };
+  }
 
   // @ngInject
   function labelifyFilter() {


### PR DESCRIPTION
Added a styled `Pediatric Cancers` example search button to the Evidence advanced search page, and added an announcement of this new feature to the homepage. Closes #1575. 

**New Example Search Button:**
<img width="1134" alt="Screen Shot 2021-02-10 at 18 14 43" src="https://user-images.githubusercontent.com/132909/107589763-4fb9a900-6bcc-11eb-9caf-c866f5c2469c.png">

**Homepage Announcement:**
<img width="1124" alt="Screen Shot 2021-02-10 at 18 14 56" src="https://user-images.githubusercontent.com/132909/107589822-724bc200-6bcc-11eb-8eda-14f89b243987.png">
